### PR TITLE
[docs] Fix typo 

### DIFF
--- a/documentation/pages/docs/options.mdx
+++ b/documentation/pages/docs/options.mdx
@@ -200,7 +200,7 @@ Forces the handler to fire even for non intentional displacement (ignores the `t
   defaultValue="{ top: -Infinity, bottom: Infinity, left: -Infinity, right: Infinity }"
 />
 
-If you want to set contraints to the user gesture, then you should use the `bounds` option. In that case, **both** the gesture `movement` and `offset` will be clamped to the specified `bounds`. `bounds` will be defaulted to `Infinity` when not set.
+If you want to set constraints to the user gesture, then you should use the `bounds` option. In that case, **both** the gesture `movement` and `offset` will be clamped to the specified `bounds`. `bounds` will be defaulted to `Infinity` when not set.
 
 <Code id="Bounds" disableOverlay />
 


### PR DESCRIPTION
`contraints` > `constraints` 👀 