### PR TITLE
Updated `useDrag`'s `preventScroll` to take in a time duration for the delay and added `preventScrollAxis` argument

### DIFF
--- a/demo/src/sandboxes/gesture-three-prevent-scroll/src/App.jsx
+++ b/demo/src/sandboxes/gesture-three-prevent-scroll/src/App.jsx
@@ -58,10 +58,13 @@ export default function App() {
       </div>
       <p style={{ padding: 20, lineHeight: 2 }}>
         <code>preventScroll</code> is a convenient way to have both vertical drag and vertical scrolling coexist. Note
-        that scroll will always have precedence over drag. To drag vertically the user will have to press the draggable
-        area for <code>250ms</code> without moving. After these <code>250ms</code> the element is draggable and scroll
-        is prevented. Note that if you drag horizontally the scroll will immediately be prevented without waiting for{' '}
-        <code>250ms</code>.
+        that scroll will always have precedence over drag. To drag vertically the user will have to press and hold the
+        draggable area for <code>250ms</code> (or the specified duration) without moving. After this duration, the
+        element is draggable and scrolling is prevented. Note that if you drag horizontally the scroll will immediately
+        be prevented without waiting for this duration. On desktop, you should be able to drag the torus as you would
+        expect without delay. On mobile, initiating scroll from the torus should let you scroll the page as expected.
+        Hold down on the torus and you should be able to drag it after <code>250ms</code>. This might be clunky as it's
+        still under testing.
       </p>
     </main>
   )

--- a/documentation/pages/docs/options.mdx
+++ b/documentation/pages/docs/options.mdx
@@ -95,28 +95,29 @@ Here are all options that can be applied to gestures.
 
 > All options are not available to all gestures. In the table below **xy** designates coordinates-based gestures: drag, move, wheel and scroll.
 
-| Options                                         |    Gestures      | Description                                                                                                                                                                                          |
-| ----------------------------------------------- | :--------------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`enabled`](#enabled)                           |     **all**      | Whether the gesture is enabled.                                                                                                                                                                      |
-| [`from`](#from)                                 |     **all**      | The initial position `offset` should start from.                                                                                                                                                     |
-| [`threshold`](#threshold)                       |     **all**      | The handler will fire only when the gesture displacement is greater than the threshold.                                                                                                              |
-| [`triggerAllEvents`](#triggerallevents)         |     **all**      | Forces the handler to fire even for non intentional displacement (ignores the `threshold`). In that case, the `intentional` attribute from state will remain `false` until the threshold is reached. |
-| [`axis`](#axis)                                 |     **all**      | Your handler will only trigger if a movement is detected on the specified axis.                                                                                                                      |
-| [`bounds`](#bounds)                             |      **xy**      | Limits the gesture `offset` to the specified bounds.                                                                                                                                                 |
-| [`scaleBounds`](#scalebounds)                   |    **pinch**     | Limits the scale `offset` to the specified bounds.                                                                                                                                                   |
-| [`angleBounds`](#anglebounds)                   |    **pinch**     | Limits the angle `offset` to the specified bounds.                                                                                                                                                   |
-| [`rubberband`](#rubberband)                     |     **all**      | The elasticity coefficient of the gesture when going out of bounds. When set to `true`, the elasticity coefficient will be defaulted to `0.15`                                                       |
-| [`transform`](#transform)                       |     **all**      | A function that you can use to transform pointer values. Useful to map your screen coordinates to custom space coordinates such as a canvas.                                                         |
-| [`filterTaps`](#filtertaps-drag-only)           |     **drag**     | If `true`, the component won't trigger your drag logic if the user just clicked on the component.                                                                                                    |
-| [`preventScroll`](#preventScroll-drag-only)     |     **drag**     | If `true`, drag will be triggered after `250ms` and will prevent window scrolling.                                                                                                                   |
-| [`pointer.touch`](#pointertouch-drag-and-pinch) |  **drag,pinch**  | If `true`, drag and pinch will use touch events on touch-enabled devices. [Read more below](#pointertouch-drag-and-pinch).                                                                           |
-| [`pointer.capture`](#pointercapture-drag-only)  |     **drag**     | If `false`, drag will not use `setPointerCapture` and attach `pointerMove` events to the window. [Read more below](#pointercapture-drag-only).                                                       |
-| [`pointer.lock`](#pointerlock-drag-only)        |     **drag**     | If `true`, the pointer will enter pointer lock mode when drag starts, and exit pointer lock when drag ends. [Read more below](#pointerlock-drag-only).                                               |
-| [`delay`](#delay-drag-only)                     |     **drag**     | If set, the handler will be delayed for the duration of the delay (in `ms`) — or if the user starts moving. When set to `true`, `delay` is defaulted to `180ms`.                                     |
-| [`swipe.distance`](#swipedistance-drag-only)    |     **drag**     | The minimum distance per axis (in `pixels`) the drag gesture needs to travel to trigger a swipe.                                                                                                     |
-| [`swipe.velocity`](#swipevelocity-drag-only)    |    **drag**      | The minimum velocity per axis (in `pixels / ms`) the drag gesture needs to reach before the pointer is released.                                                                                     |
-| [`swipe.duration`](#swipeduration-drag-only)    |    **drag**      | The maximum duration in milliseconds that a swipe is detected.                                                                                                                                       |
-| `mouseOnly`                                     | **hover, move**  | Set to `false` if you want your `hover` or `move` handlers to be triggered on non-mouse events. This is a useful option in case you want to perform logic on touch-enabled devices.                  |
+| Options                                             |    Gestures     | Description                                                                                                                                                                                          |
+| --------------------------------------------------- | :-------------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`enabled`](#enabled)                               |     **all**     | Whether the gesture is enabled.                                                                                                                                                                      |
+| [`from`](#from)                                     |     **all**     | The initial position `offset` should start from.                                                                                                                                                     |
+| [`threshold`](#threshold)                           |     **all**     | The handler will fire only when the gesture displacement is greater than the threshold.                                                                                                              |
+| [`triggerAllEvents`](#triggerallevents)             |     **all**     | Forces the handler to fire even for non intentional displacement (ignores the `threshold`). In that case, the `intentional` attribute from state will remain `false` until the threshold is reached. |
+| [`axis`](#axis)                                     |     **all**     | Your handler will only trigger if a movement is detected on the specified axis.                                                                                                                      |
+| [`bounds`](#bounds)                                 |     **xy**      | Limits the gesture `offset` to the specified bounds.                                                                                                                                                 |
+| [`scaleBounds`](#scalebounds)                       |    **pinch**    | Limits the scale `offset` to the specified bounds.                                                                                                                                                   |
+| [`angleBounds`](#anglebounds)                       |    **pinch**    | Limits the angle `offset` to the specified bounds.                                                                                                                                                   |
+| [`rubberband`](#rubberband)                         |     **all**     | The elasticity coefficient of the gesture when going out of bounds. When set to `true`, the elasticity coefficient will be defaulted to `0.15`                                                       |
+| [`transform`](#transform)                           |     **all**     | A function that you can use to transform pointer values. Useful to map your screen coordinates to custom space coordinates such as a canvas.                                                         |
+| [`filterTaps`](#filtertaps-drag-only)               |    **drag**     | If `true`, the component won't trigger your drag logic if the user just clicked on the component.                                                                                                    |
+| [`preventScroll`](#preventScroll-drag-only)         |    **drag**     | If set, the drag will be triggered after the duration of the delay (in `ms`) and will prevent window scrolling. When set to `true`, `preventScroll` is defaulted to `250ms`.                         |
+| [`preventScrollAxis`](#preventScrollAxis-drag-only) |    **drag**     | If set, the drag will allow scrolling in the direction of the axis/axes unless the preventScroll duration has elapsed. Defaults to only 'y'.                                                         |
+| [`pointer.touch`](#pointertouch-drag-and-pinch)     | **drag,pinch**  | If `true`, drag and pinch will use touch events on touch-enabled devices. [Read more below](#pointertouch-drag-and-pinch).                                                                           |
+| [`pointer.capture`](#pointercapture-drag-only)      |    **drag**     | If `false`, drag will not use `setPointerCapture` and attach `pointerMove` events to the window. [Read more below](#pointercapture-drag-only).                                                       |
+| [`pointer.lock`](#pointerlock-drag-only)            |    **drag**     | If `true`, the pointer will enter pointer lock mode when drag starts, and exit pointer lock when drag ends. [Read more below](#pointerlock-drag-only).                                               |
+| [`delay`](#delay-drag-only)                         |    **drag**     | If set, the handler will be delayed for the duration of the delay (in `ms`) — or if the user starts moving. When set to `true`, `delay` is defaulted to `180ms`.                                     |
+| [`swipe.distance`](#swipedistance-drag-only)        |    **drag**     | The minimum distance per axis (in `pixels`) the drag gesture needs to travel to trigger a swipe.                                                                                                     |
+| [`swipe.velocity`](#swipevelocity-drag-only)        |    **drag**     | The minimum velocity per axis (in `pixels / ms`) the drag gesture needs to reach before the pointer is released.                                                                                     |
+| [`swipe.duration`](#swipeduration-drag-only)        |    **drag**     | The maximum duration in milliseconds that a swipe is detected.                                                                                                                                       |
+| `mouseOnly`                                         | **hover, move** | Set to `false` if you want your `hover` or `move` handlers to be triggered on non-mouse events. This is a useful option in case you want to perform logic on touch-enabled devices.                  |
 
 ## Options explained
 
@@ -440,13 +441,19 @@ function FilterTapsExample() {
 
 **This is an experimental feature, relevant for mobile devices**.
 
-`touch-action: none` is a common css property that you'll set on draggable items so that scroll doesn't interfere with the drag behavior on touch devices. However, this generally means that the scroll of the page can't be initiated from the draggable element. This is fine if your page isn't meant to be scrolled or if your draggable element is relatively small, but in case of large draggable areas this might become a usability issue.
+`touch-action: none` is a common CSS property that you'll set on draggable items so that scroll doesn't interfere with the drag behavior on touch devices. However, this generally means that the scroll of the page can't be initiated from the draggable element. This is fine if your page isn't meant to be scrolled or if your draggable element is relatively small, but in case of large draggable areas this might become a usability issue.
 
-`preventScroll` is a convenient way to have both vertical drag and vertical scrolling coexist. Note that scroll will always have precedence over drag. To drag vertically the user will have to press the draggable area for `250ms` without moving. After these `250ms` the element is draggable and scroll is prevented. Note that if you drag horizontally the scroll will immediately be prevented without waiting for `250ms`.
+`preventScroll` is a convenient way to have both vertical drag and vertical scrolling coexist. Note that scroll will always have precedence over drag. To drag vertically the user will have to press and hold the draggable area for `250ms` (or the specified duration) without moving. After this duration, the element is draggable and scrolling is prevented. Note that if you drag horizontally the scroll will immediately be prevented without waiting for this duration.
 
 <Code id="PreventScroll" />
 
-On desktop, you should be able to drag the torus as you would expect. On mobile, initiating the scroll from the torus should let you scroll the page as expected. Hold touch and drag and you should be able to drag the canvas. This might be clunky as still under test.
+On desktop, you should be able to drag the torus as you would expect without delay. On mobile, initiating scroll from the torus should let you scroll the page as expected. Hold down on the torus and you should be able to drag it after `250ms`. This might be clunky as it's still under testing.
+
+### preventScrollAxis (drag only)
+
+<Specs types={['x', 'y', 'xy']} defaultValue="y" />
+
+This can optionally be used together with `preventScroll`. This defines the axis/axes in which scrolling is permitted, unless the user taps and holds on the element for the specified duration. Afterwhich, all scrolling is blocked. Depending on the complexity of the nesting of the element, you may need to assign the property `touch-action: pan-x`, `touch-action: pan-y`, or both, to the element to allow for the correct behavior.
 
 ### pointer.touch (drag and pinch)
 
@@ -458,7 +465,7 @@ Most gestures, drag included, use [pointer events](https://developer.mozilla.org
 
 <Specs types={'boolean'} defaultValue="true" />
 
-By default, drag uses [`setPointerCapture`](https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture) to track the pointer movement. When a pointer is captured by a target, it won't trigger any listener from another target (even a css `:hover`). Most of the time this is fine, but in some situations, you may want to drag an element and still receive events from another target.
+By default, drag uses [`setPointerCapture`](https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture) to track the pointer movement. When a pointer is captured by a target, it won't trigger any listener from another target (even a CSS `:hover`). Most of the time this is fine, but in some situations, you may want to drag an element and still receive events from another target.
 
 <Code id="CaptureFalse" />
 

--- a/packages/core/src/config/dragConfigResolver.ts
+++ b/packages/core/src/config/dragConfigResolver.ts
@@ -3,6 +3,7 @@ import { V } from '../utils/maths'
 import { coordinatesConfigResolver } from './coordinatesConfigResolver'
 import { SUPPORT } from './support'
 
+export const DEFAULT_PREVENT_SCROLL_DELAY = 250
 export const DEFAULT_DRAG_DELAY = 180
 export const DEFAULT_SWIPE_VELOCITY = 0.5
 export const DEFAULT_SWIPE_DISTANCE = 50
@@ -26,8 +27,16 @@ export const dragConfigResolver = {
     if (SUPPORT.touch) return 'touch'
     return 'mouse'
   },
-  preventScroll(value = false) {
-    return value && SUPPORT.touch
+  preventScroll(
+    this: InternalDragOptions,
+    value: number | boolean = false,
+    _k: string,
+    { preventScrollAxis = 'y' }: DragConfig
+  ) {
+    if (preventScrollAxis) this.preventScrollAxis = preventScrollAxis
+    if (!SUPPORT.touch) return false
+    if (typeof value === 'number') return value
+    return value ? DEFAULT_PREVENT_SCROLL_DELAY : false
   },
   pointerCapture(this: InternalDragOptions, _v: any, _k: string, { pointer: { capture = true } = {} }) {
     return !this.pointerLock && this.device === 'pointer' && capture

--- a/packages/core/src/engines/DragEngine.ts
+++ b/packages/core/src/engines/DragEngine.ts
@@ -141,13 +141,13 @@ export class DragEngine extends CoordinatesEngine<'drag'> {
 
     if (config.preventScroll && !state._preventScroll) {
       if (state.axis) {
-        if (state.axis === 'x') {
-          this.timeoutStore.remove('startPointerDrag')
-          this.startPointerDrag(event)
-          return
-        } else {
+        if (state.axis === config.preventScrollAxis || config.preventScrollAxis === 'xy') {
           state._active = false
           this.clean()
+          return
+        } else {
+          this.timeoutStore.remove('startPointerDrag')
+          this.startPointerDrag(event)
           return
         }
       } else {
@@ -260,7 +260,7 @@ export class DragEngine extends CoordinatesEngine<'drag'> {
     this.eventStore.add(this.sharedConfig.window!, 'touch', 'change', this.preventScroll.bind(this), { passive: false })
     this.eventStore.add(this.sharedConfig.window!, 'touch', 'end', this.clean.bind(this), { passive: false })
     this.eventStore.add(this.sharedConfig.window!, 'touch', 'cancel', this.clean.bind(this), { passive: false })
-    this.timeoutStore.add('startPointerDrag', this.startPointerDrag.bind(this), 250, event)
+    this.timeoutStore.add('startPointerDrag', this.startPointerDrag.bind(this), this.config.preventScroll, event)
   }
 
   setupDelayTrigger(event: PointerEvent) {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -165,10 +165,15 @@ export type DragConfig = CoordinatesConfig<'drag'> & {
     duration?: number
   }
   /**
-   * If true, drag will be triggered after 250ms and will prevent window
-   * scrolling.
+   * If set, the drag will be triggered after the duration of the delay (in ms).
+   * When set to true, delay is defaulted to 250ms.
    */
-  preventScroll?: boolean
+  preventScroll?: boolean | number
+  /**
+   * If set, the drag will allow scrolling in the direction of this axis until
+   * the preventScroll duration has elapsed. Defaults to only 'y'.
+   */
+  preventScrollAxis?: 'x' | 'y' | 'xy'
   /**
    * If set, the handler will be delayed for the duration of the delay (in ms)
    * — or if the user starts moving. When set to true, delay is defaulted

--- a/packages/core/src/types/internalConfig.ts
+++ b/packages/core/src/types/internalConfig.ts
@@ -29,7 +29,8 @@ export type InternalDragOptions = InternalCoordinatesOptions<'drag'> & {
   filterTaps: boolean
   useTouch: boolean
   pointerCapture: boolean
-  preventScroll: boolean
+  preventScroll: number
+  preventScrollAxis: 'x' | 'y' | 'xy'
   pointerLock: boolean
   device: 'pointer' | 'touch' | 'mouse'
   swipe: {

--- a/test/config.test.tsx
+++ b/test/config.test.tsx
@@ -46,6 +46,7 @@ describe('testing derived config', () => {
 
   describe('testing drag configuration', () => {
     test(`empty config should return default drag config`, () => {
+      console.log(parse({}, 'drag'))
       expect(parse({}, 'drag').drag).toStrictEqual({
         enabled: true,
         device: 'pointer',
@@ -67,6 +68,7 @@ describe('testing derived config', () => {
         axis: undefined,
         lockDirection: false,
         preventScroll: false,
+        preventScrollAxis: 'y',
         pointerLock: false,
         pointerCapture: true,
         filterTaps: false,


### PR DESCRIPTION
Hi, this is the updated version of my [previous PR, as the branch got a little bugged out so I had to redo it](https://github.com/pmndrs/use-gesture/pull/308).

I've updated the `preventScroll` argument for the `useDrag` handler to accept a duration in `ms` to act as the "long press" before dragging is initiated. If set to true, this defaults to 250ms.

I've also added a `preventScrollAxis` argument for `useDrag`, which accepts `'x' | 'y' | 'xy'` and defaults to 'y'. This argument will make it such that it allows for scrolling in the direction of the defined axis, but when the "long press" duration has elapsed, the scrolling will be blocked. In the other axis, there is no delay before dragging is triggered, which is the expected behavior. Depending on the nesting of the drag element, `touch-action: pan-x` or `touch-action: pan-y`, or both, may need to be assigned to the element.

I will note however that the wording of `preventScrollAxis` can be a little misleading because it can imply that scrolling in the defined direction is prevented when in fact it is allowed until after the "long press" duration has elapsed. But in essence what this means is that scrolling over the element is allowed along the `preventScrollAxis` until after the `preventScroll` duration has elapsed, after which scrolling is prevented.

All tests and type checks have passed, and documentation has been updated to reflect the changes.

Thanks!