### PR TITLE
fix: unexpected velocity at end of gesture

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -18,9 +18,11 @@
     "leva": "*",
     "lodash-move": "^1.1.1",
     "lodash.clamp": "^4.0.3",
+    "popmotion": "^9.4.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-use-measure": "^2.0.4",
+    "stylefire": "^7.0.3",
     "three": "^0.129.0",
     "wouter": "^2.7.4"
   },

--- a/demo/src/App.jsx
+++ b/demo/src/App.jsx
@@ -23,6 +23,7 @@ import CardZoom from './sandboxes/card-zoom/src/App'
 import InfiniteSlideshow from './sandboxes/infinite-slideshow/src/App'
 import ActionSheet from './sandboxes/action-sheet/src/App'
 import DotsConnect from './sandboxes/dots-connect/src/App'
+import VanillaThrow from './sandboxes/vanilla-throw/src/App'
 
 const links = {
   'gesture-simplest': Simplest,
@@ -44,7 +45,8 @@ const links = {
   'card-zoom': CardZoom,
   'infinite-slideshow': InfiniteSlideshow,
   'action-sheet': ActionSheet,
-  'dots-connect': DotsConnect
+  'dots-connect': DotsConnect,
+  'vanilla-throw': VanillaThrow
 }
 
 const Example = ({ link }) => {

--- a/demo/src/sandboxes/vanilla-throw/package.json
+++ b/demo/src/sandboxes/vanilla-throw/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "vanilla-throw",
+  "version": "1.0.0",
+  "main": "src/index.jsx",
+  "dependencies": {
+    "@use-gesture/vanilla": "latest",
+    "popmotion": "9.4.0",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
+    "react-scripts": "4.0.3",
+    "stylefire": "7.0.3"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  }
+}

--- a/demo/src/sandboxes/vanilla-throw/public/index.html
+++ b/demo/src/sandboxes/vanilla-throw/public/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="theme-color" content="#000000" />
+    <!--
+      manifest.json provides metadata used when your web app is added to the
+      homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
+    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+    <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+    <title>@use-gesture Sandbox</title>
+  </head>
+
+  <body>
+    <noscript> You need to enable JavaScript to run this app. </noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+  </body>
+</html>

--- a/demo/src/sandboxes/vanilla-throw/src/App.jsx
+++ b/demo/src/sandboxes/vanilla-throw/src/App.jsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { inertia } from 'popmotion'
+import styler from 'stylefire'
+import { DragGesture } from '@use-gesture/vanilla'
+
+import './styles.css'
+import { DemoDrags } from './demo-util'
+
+function readyApp() {
+  const puck = document.querySelector('.puck')
+
+  const puckStyler = styler(puck)
+  const inertiaEnders = []
+  const stopInertia = () => {
+    while (inertiaEnders.length) inertiaEnders.pop().stop()
+  }
+
+  const bounds = document.querySelector('.bounds')
+  const xRange = bounds.offsetWidth / 2 - puck.offsetWidth / 2
+  const yRange = bounds.offsetHeight / 2 - puck.offsetWidth / 2
+
+  const gesture = new DragGesture(
+    puck,
+    ({ active, first, offset: [x, y], direction: [dx, dy], velocity: [vx, vy] }) => {
+      if (first) {
+        stopInertia()
+        puck.className += ' active'
+      }
+      puckStyler.set({ x, y })
+      if (!active) {
+        puck.className = 'puck'
+        console.log('velocity at gesture end', [vx, vy])
+        inertiaEnders.push(
+          inertia({
+            from: x,
+            power: 1,
+            velocity: dx * vx * 500,
+            min: -xRange,
+            max: xRange,
+            onUpdate: (v) => puckStyler.set('x', v)
+          }),
+          inertia({
+            from: y,
+            power: 1,
+            velocity: dy * vy * 500,
+            min: -yRange,
+            max: yRange,
+            onUpdate: (v) => puckStyler.set('y', v)
+          })
+        )
+      }
+    },
+    {
+      from: () => [puckStyler.get('x'), puckStyler.get('y')]
+    }
+  )
+
+  return gesture.destroy.bind(gesture)
+}
+
+export default function App() {
+  const isMounted = useRef()
+  const [puck, setPuck] = useState()
+  useEffect(() => {
+    const cleanup = isMounted.current && readyApp()
+    isMounted.current = true
+    return cleanup
+  })
+  return (
+    <div className="flex fill center">
+      <div className="bounds">
+        <div className="puck" ref={setPuck}></div>
+      </div>
+      <DemoDrags subject={puck} />
+    </div>
+  )
+}

--- a/demo/src/sandboxes/vanilla-throw/src/demo-util.jsx
+++ b/demo/src/sandboxes/vanilla-throw/src/demo-util.jsx
@@ -1,0 +1,150 @@
+import React, { useState, useRef } from 'react'
+import { animate, easeIn, linear, interpolate } from 'popmotion'
+
+const directions = {
+  nw: [-1, -1],
+  n: [0, -1],
+  ne: [1, -1],
+  w: [-1, 0],
+  e: [1, 0],
+  sw: [-1, 1],
+  s: [0, 1],
+  se: [1, 1]
+}
+
+export function DemoDrags({ subject }) {
+  const refDemo = useRef()
+  const [magnitude, setMagnitude] = useState(60)
+  const [timing, setTiming] = useState(20)
+  const [duration, setDuration] = useState(500)
+  if (!subject) return null
+  return (
+    <div className="demo-drags">
+      <h2 htmlFor="drag-magnitude">Drag simulator</h2>
+      <div className="demo-drags/button-grid">
+        {Object.keys(directions).map((key) => {
+          const vector = directions[key].map((v) => v * magnitude)
+          return (
+            <button
+              key={key}
+              className={`demo-drags/button-${key}`}
+              onClick={() => {
+                if (refDemo.current?.stop) {
+                  refDemo.current.stop()
+                }
+                const offset = (duration - timing) / duration
+                refDemo.current = demo(subject, vector, duration, offset)
+              }}
+            >
+              {key}
+            </button>
+          )
+        })}
+        <input
+          id="drag-magnitude"
+          type="number"
+          min="3"
+          max="60"
+          value={magnitude}
+          onChange={({ target: { value } }) => setMagnitude(+value)}
+        />
+      </div>
+      <div className="demo-drags/timings">
+        <label>
+          Drag duration:
+          <input
+            type="number"
+            min="16"
+            max="2000"
+            value={duration}
+            onChange={({ target: { value } }) => setDuration(+value)}
+          />
+        </label>
+        <label>
+          Drag end delay (after motion stops):
+          <input
+            type="number"
+            min="0"
+            max="1000"
+            value={timing}
+            onChange={({ target: { value } }) => setTiming(+value)}
+          />
+        </label>
+      </div>
+    </div>
+  )
+}
+
+function demo(target, [byX, byY], duration, offset) {
+  const targetRect = target.getBoundingClientRect()
+  const startX = targetRect.x + targetRect.width / 2
+  const startY = targetRect.y + targetRect.height / 2
+  const endX = startX + byX
+  const endY = startY + byY
+
+  const mapProgressToCoords = interpolate(
+    [0, 1],
+    [
+      [startX, startY],
+      [endX, endY]
+    ]
+  )
+
+  dispatchAtCoords(target, 'pointerdown', startX, startY)
+
+  let lastValue
+  // generates move events, tarries a bit, then dispatches the up event
+  return animate({
+    to: [0, 1, 1],
+    offset: [0, offset, 1],
+    ease: [easeIn, linear],
+    duration,
+    onUpdate: (value) => {
+      // avoids dispatch if the position hasn't changed, like the real thing
+      if (value === lastValue) return
+      lastValue = value
+      const [x, y] = mapProgressToCoords(value)
+      dispatchAtCoords(target, 'pointermove', x, y)
+    },
+    onComplete: () => {
+      dispatchAtCoords(target, 'pointerup', endX, endY)
+    },
+    driver: makeTimeoutDriver(4)
+  })
+}
+
+function dispatchAtCoords(target, name, x, y) {
+  const event = document.createEvent('CustomEvent')
+  event.initCustomEvent(name, true, true, null)
+  event.pointerId = 1
+  event.clientX = x
+  event.clientY = y
+  target.dispatchEvent(event)
+}
+
+const makeTimeoutDriver = (interval) => (update) => {
+  let timeoutId
+  let lastTimestamp = performance.now()
+  let isActive = true
+
+  const tick = () => {
+    const timestamp = performance.now()
+    const delta = timestamp - lastTimestamp
+    lastTimestamp = timestamp
+
+    update(delta)
+
+    if (!isActive) return
+    timeoutId = setTimeout(tick, interval)
+  }
+
+  return {
+    start: () => {
+      timeoutId = setTimeout(tick, interval)
+    },
+    stop: () => {
+      isActive = false
+      clearTimeout(timeoutId)
+    }
+  }
+}

--- a/demo/src/sandboxes/vanilla-throw/src/index.css
+++ b/demo/src/sandboxes/vanilla-throw/src/index.css
@@ -1,0 +1,31 @@
+html,
+body,
+#root {
+  height: 100%;
+  width: 100%;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  min-height: 100vh;
+  margin: 0;
+}
+
+*,
+*:after,
+*:before {
+  box-sizing: border-box;
+}
+
+.flex {
+  display: flex;
+  align-items: center;
+}
+
+.flex.fill {
+  height: 100%;
+}
+
+.flex.center {
+  justify-content: center;
+}

--- a/demo/src/sandboxes/vanilla-throw/src/index.jsx
+++ b/demo/src/sandboxes/vanilla-throw/src/index.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import App from './App'
+
+import './index.css'
+
+const rootElement = document.getElementById('root')
+ReactDOM.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+  rootElement
+)

--- a/demo/src/sandboxes/vanilla-throw/src/styles.css
+++ b/demo/src/sandboxes/vanilla-throw/src/styles.css
@@ -1,0 +1,74 @@
+html,
+body {
+  height: 100%;
+  margin: 0;
+}
+body {
+  font-family: sans-serif;
+}
+#app {
+  background: gainsboro;
+  display: flex;
+  height: 100%;
+  flex: 1;
+}
+.bounds {
+  margin: auto;
+  flex: 0 1 360px;
+  height: 360px;
+  box-shadow: 0 0 0 1px #dddddd;
+  --grid-line: #dddddd, #dddddd 1px, #dddddd00 1px, #dddddd00 59px, #dddddd 59px, #dddddd 60px;
+  background: repeating-linear-gradient(var(--grid-line)), repeating-linear-gradient(90deg, var(--grid-line)) whitesmoke;
+  display: flex;
+}
+.puck {
+  touch-action: none;
+  background: hotpink;
+  border: 1px solid deeppink;
+  width: 60px;
+  height: 60px;
+  cursor: grab;
+  margin: auto;
+  color: #fff;
+  display: flex;
+}
+.puck:active {
+  cursor: grabbing;
+}
+.puck.active {
+  background: deeppink;
+}
+.puck:before {
+  content: 'drag';
+  margin: auto;
+}
+.puck.active:before {
+  content: 'drop';
+}
+
+.demo-drags {
+  flex: 0;
+  margin: auto auto auto 0;
+}
+.demo-drags\/button-grid {
+  display: grid;
+  grid-template: 1fr 1fr 1fr / 1fr 1fr 1fr;
+  width: 8em;
+  height: 8em;
+}
+.demo-drags\/button-grid > [type='number'] {
+  grid-area: 2/2;
+}
+
+.demo-drags\/timings {
+  display: flex;
+  flex-flow: column;
+}
+.demo-drags\/timings label {
+  font-size: 0.8em;
+  margin: 0.8em 0 0;
+}
+.demo-drags\/timings label > input {
+  margin-top: 0.25em;
+  display: block;
+}

--- a/packages/core/src/types/state.ts
+++ b/packages/core/src/types/state.ts
@@ -102,6 +102,10 @@ export type CommonGestureState = {
    */
   movement: Vector2
   /**
+   * Previous displacement of the current gesture.
+   */
+  previousMovement: Vector2
+  /**
    * Difference between the current movement and the previous movement.
    */
   delta: Vector2


### PR DESCRIPTION
To fix #332, now on input events the engine queues an update to a previous movement state value and calculates velocity on last input event using that. 

**How this was tested** 
Besides verifying all unit tests still pass, this was tested manually with a version of the sandbox I'd made for #332 converted into on of the `demo/` sandboxes. If that sounds helpful for testing (or if it's just good to have another vanilla demo) I could submit as another PR.

https://user-images.githubusercontent.com/9000376/126075330-3ab47cc0-7be2-4e0b-b1ea-5c7cc6205777.mp4




