### PR TITLE
fix: trying to fix #332 with arbitrary heuristics

### DIFF
--- a/demo/src/index.jsx
+++ b/demo/src/index.jsx
@@ -4,7 +4,7 @@ import App from './App'
 
 import './index.css'
 
-// window.screenLog.init()
+window.screenLog.init()
 
 const rootElement = document.getElementById('root')
 ReactDOM.render(

--- a/demo/src/sandboxes/gesture-simplest/src/App.tsx
+++ b/demo/src/sandboxes/gesture-simplest/src/App.tsx
@@ -6,12 +6,14 @@ import styles from './styles.module.css'
 
 export default function App() {
   const [style, api] = useSpring(() => ({ x: 0, y: 0, scale: 1 }))
-  const bind = useDrag(({ active, movement: [x, y] }) => {
+  const bind = useDrag(({ active, delta, movement: [x, y], velocity, timeStamp, memo = 0 }) => {
+    if (!active) console.log(timeStamp - memo, delta, velocity)
     api.start({
       x: active ? x : 0,
       y: active ? y : 0,
       scale: active ? 1.2 : 1
     })
+    return timeStamp
   })
 
   return (

--- a/packages/core/src/engines/Engine.ts
+++ b/packages/core/src/engines/Engine.ts
@@ -4,6 +4,8 @@ import { call } from '../utils/fn'
 import { V, computeRubberband } from '../utils/maths'
 import { GestureKey, IngKey, State, Vector2 } from '../types'
 
+const BEFORE_LAST_KINEMATICS_DELAY = 32
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface Engine<Key extends GestureKey> {
   /**
@@ -249,7 +251,7 @@ export abstract class Engine<Key extends GestureKey> {
 
         this.computeOffset()
 
-        if (!state.last) {
+        if (!state.last || dt > BEFORE_LAST_KINEMATICS_DELAY) {
           state.delta = V.sub(movement, previousMovement)
           const absoluteDelta = state.delta.map(Math.abs) as Vector2
 

--- a/packages/core/src/engines/Engine.ts
+++ b/packages/core/src/engines/Engine.ts
@@ -8,7 +8,7 @@ import { GestureKey, IngKey, State, Vector2 } from '../types'
  * The lib doesn't compute the kinematics on the last event of the gesture
  * (i.e. for a drag gesture, the `pointerup` coordinates will generally match the
  * last `pointermove` coordinates which would result in all drags ending with a
- * `[0,0]` velocity). However, hen the timestamp difference between the last
+ * `[0,0]` velocity). However, when the timestamp difference between the last
  * event (ie pointerup) and the before last event (ie pointermove) is greater
  * than BEFORE_LAST_KINEMATICS_DELAY, the kinematics are computed (which would
  * mean that if you release your drag after stopping for more than

--- a/packages/core/src/engines/Engine.ts
+++ b/packages/core/src/engines/Engine.ts
@@ -4,6 +4,19 @@ import { call } from '../utils/fn'
 import { V, computeRubberband } from '../utils/maths'
 import { GestureKey, IngKey, State, Vector2 } from '../types'
 
+/**
+ * The lib doesn't compute the kinematics on the last event of the gesture
+ * (i.e. for a drag gesture, the `pointerup` coordinates will generally match the
+ * last `pointermove` coordinates which would result in all drags ending with a
+ * `[0,0]` velocity). However, hen the timestamp difference between the last
+ * event (ie pointerup) and the before last event (ie pointermove) is greater
+ * than BEFORE_LAST_KINEMATICS_DELAY, the kinematics are computed (which would
+ * mean that if you release your drag after stopping for more than
+ * BEFORE_LAST_KINEMATICS_DELAY, the velocity will be indeed 0).
+ *
+ * See https://github.com/pmndrs/use-gesture/pull/337 for more details.
+ */
+
 const BEFORE_LAST_KINEMATICS_DELAY = 32
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/core/src/engines/Engine.ts
+++ b/packages/core/src/engines/Engine.ts
@@ -14,7 +14,7 @@ import { GestureKey, IngKey, State, Vector2 } from '../types'
  * mean that if you release your drag after stopping for more than
  * BEFORE_LAST_KINEMATICS_DELAY, the velocity will be indeed 0).
  *
- * See https://github.com/pmndrs/use-gesture/pull/337 for more details.
+ * See https://github.com/pmndrs/use-gesture/issues/332 for more details.
  */
 
 const BEFORE_LAST_KINEMATICS_DELAY = 32


### PR DESCRIPTION
This is an alternative to #337, which **does** compute velocity on the `last` event when the timestamp delta is greater than an arbitrary value (here set to `32 ms`).

I've added a console.log in the gesture-simplest demo (http://localhost:4000/gesture-simplest after running `pnpm demo:dev`, which prints the timestamp delta between the last event (`pointerup`) and before last event (`pointermove`), the movement `delta`, and the `velocity`.

@stokesman, let me know if that kinda fixes it for you, you can tweak the value to see if you get better results with your demo.