### PR TITLE
feat: warn in dev mode if transform function return invalid values

### DIFF
--- a/.changeset/metal-rivers-search.md
+++ b/.changeset/metal-rivers-search.md
@@ -1,0 +1,5 @@
+---
+"@use-gesture/core": patch
+---
+
+feat: warn in dev mode if transform function return invalid values

--- a/packages/core/src/engines/Engine.ts
+++ b/packages/core/src/engines/Engine.ts
@@ -228,6 +228,16 @@ export abstract class Engine<Key extends GestureKey> {
     }
 
     const [_m0, _m1] = config.transform(state._movement)
+
+    if (process.env.NODE_ENV === 'development') {
+      if (typeof _m0 !== 'number' || typeof _m1 !== 'number') {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[@use-gesture]: config.transform() must produce a valid result, but it was: [${_m0},${_m1}]`
+        )
+      }
+    }
+
     const [_t0, _t1] = state._threshold
     // Step will hold the threshold at which point the gesture was triggered. The
     // threshold is signed depending on which direction triggered it.

--- a/packages/core/src/engines/Engine.ts
+++ b/packages/core/src/engines/Engine.ts
@@ -230,7 +230,8 @@ export abstract class Engine<Key extends GestureKey> {
     const [_m0, _m1] = config.transform(state._movement)
 
     if (process.env.NODE_ENV === 'development') {
-      if (typeof _m0 !== 'number' || typeof _m1 !== 'number') {
+      const isNumberAndNotNaN = (v: any) => typeof v === 'number' && !Number.isNaN(v);
+      if (!isNumberAndNotNaN(_m0) || !isNumberAndNotNaN(_m1)) {
         // eslint-disable-next-line no-console
         console.warn(
           `[@use-gesture]: config.transform() must produce a valid result, but it was: [${_m0},${_m1}]`


### PR DESCRIPTION
This PR will print a console warning when `process.env.NODE_ENV === 'develop'` if the `config.transform()` function does not return valid numerical values.

In other words it shall return an array of two values where both values are of number type and not `NaN`.