### PR TITLE
Adding a custom threshold to taps when filtering them

### DIFF
--- a/.changeset/loud-colts-design.md
+++ b/.changeset/loud-colts-design.md
@@ -1,0 +1,5 @@
+---
+"@use-gesture/core": patch
+---
+
+[Drag] feat: Adding a custom threshold to taps when filtering them (`tapThreshold`)

--- a/documentation/pages/docs/options.mdx
+++ b/documentation/pages/docs/options.mdx
@@ -108,8 +108,9 @@ Here are all options that can be applied to gestures.
 | [`rubberband`](#rubberband)               |     **all**     | The elasticity coefficient of the gesture when going out of bounds. When set to `true`, the elasticity coefficient will be defaulted to `0.15`                                                       |
 | [`transform`](#transform)                 |     **all**     | A function that you can use to transform pointer values. Useful to map your screen coordinates to custom space coordinates such as a canvas.                                                         |
 | [`filterTaps`](#filtertaps)               |    **drag**     | If `true`, the component won't trigger your drag logic if the user just clicked on the component.                                                                                                    |
-| [`preventScroll`](#preventScroll)         |    **drag**     | If set, the drag will be triggered after the duration of the delay (in `ms`) and will prevent window scrolling. When set to `true`, `preventScroll` is defaulted to `250ms`.                         |
-| [`preventScrollAxis`](#preventScrollAxis) |    **drag**     | If set, the drag will allow scrolling in the direction of the axis/axes unless the preventScroll duration has elapsed. Defaults to only 'y'.                                                         |
+| [`tapsThreshold`](#tapsthreshold)         |    **drag**     | Customize the displacement triggering taps when using the `filterTaps` option. Default is `3`.                                                                                                       |
+| [`preventScroll`](#preventscroll)         |    **drag**     | If set, the drag will be triggered after the duration of the delay (in `ms`) and will prevent window scrolling. When set to `true`, `preventScroll` is defaulted to `250ms`.                         |
+| [`preventScrollAxis`](#preventscrollaxis) |    **drag**     | If set, the drag will allow scrolling in the direction of the axis/axes unless the preventScroll duration has elapsed. Defaults to only 'y'.                                                         |
 | [`pointer.touch`](#pointertouch)          | **drag,pinch**  | If `true`, drag and pinch will use touch events on touch-enabled devices. [Read more below](#pointertouch).                                                                                          |
 | [`pointer.capture`](#pointercapture)      |    **drag**     | If `false`, drag will not use `setPointerCapture` and attach `pointerMove` events to the window. [Read more below](#pointercapture).                                                                 |
 | [`pointer.buttons`](#pointerbuttons)      |    **drag**     | Combination of buttons that triggers the drag gesture. [Read more below](#pointerbuttons).                                                                                                           |
@@ -270,6 +271,8 @@ function FilterTapsExample() {
 ```
 
 > If you still want your handler to be triggered for non intentional displacement, this is where the `triggerAllEvents` config option and the `intentional` state attribute become useful.
+
+> If you want to configure the minimum displacement for the tap to be triggered, have a look at the [tapsThreshold option](#tapsThreshold)
 
 ### from
 
@@ -436,6 +439,12 @@ A drag gesture lasting moore than `swipe.duration` (in milliseconds) will never 
 <Specs gestures={['drag']} types={['number', 'vector']} defaultValue="[0.5,0.5]" />
 
 See the [`swipe`](/docs/state/#swipe) state attribute for more.
+
+### tapsThreshold
+
+<Specs gestures={['drag']} types={['number']} defaultValue="3" />
+
+When using the [filterTaps](#filterTaps) option, taps are only triggered when the displacement is inferior to `3` pixels. You can customize that value by using `tapsThreshold`.
 
 ### target (React only)
 

--- a/packages/core/src/config/dragConfigResolver.ts
+++ b/packages/core/src/config/dragConfigResolver.ts
@@ -44,7 +44,7 @@ export const dragConfigResolver = {
   },
   threshold(this: InternalDragOptions, value: number | Vector2, _k: string, { filterTaps = false, tapsThreshold = 3, axis = undefined }) {
     // TODO add warning when value is 0 and filterTaps or axis is set
-    const threshold = V.toVector(value, filterTaps ? 3 : axis ? 1 : 0)
+    const threshold = V.toVector(value, filterTaps ? tapsThreshold : axis ? 1 : 0)
     this.filterTaps = filterTaps
     this.tapsThreshold = tapsThreshold
     return threshold

--- a/packages/core/src/config/dragConfigResolver.ts
+++ b/packages/core/src/config/dragConfigResolver.ts
@@ -42,10 +42,11 @@ export const dragConfigResolver = {
     this.pointerButtons = buttons
     return !this.pointerLock && this.device === 'pointer' && capture
   },
-  threshold(this: InternalDragOptions, value: number | Vector2, _k: string, { filterTaps = false, axis = undefined }) {
+  threshold(this: InternalDragOptions, value: number | Vector2, _k: string, { filterTaps = false, tapsThreshold = 3, axis = undefined }) {
     // TODO add warning when value is 0 and filterTaps or axis is set
     const threshold = V.toVector(value, filterTaps ? 3 : axis ? 1 : 0)
     this.filterTaps = filterTaps
+    this.tapsThreshold = tapsThreshold
     return threshold
   },
   swipe(

--- a/packages/core/src/engines/DragEngine.ts
+++ b/packages/core/src/engines/DragEngine.ts
@@ -207,7 +207,7 @@ export class DragEngine extends CoordinatesEngine<'drag'> {
     this.compute(event)
 
     const [dx, dy] = state._distance
-    state.tap = dx <= 3 && dy <= 3
+    state.tap = dx <= config.tapsThreshold && dy <= config.tapsThreshold
 
     if (state.tap && config.filterTaps) {
       state._force = true

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -128,6 +128,10 @@ export type DragConfig = CoordinatesConfig<'drag'> & {
    */
   filterTaps?: boolean
   /**
+   * The maximum total displacement a tap can have   
+   */
+  tapsThreshold?: number
+  /**
    * Set this option to true when using with @react-three/fiber objects.
    */
   /**

--- a/packages/core/src/types/internalConfig.ts
+++ b/packages/core/src/types/internalConfig.ts
@@ -29,6 +29,7 @@ export type InternalCoordinatesOptions<Key extends CoordinatesKey = CoordinatesK
 
 export type InternalDragOptions = InternalCoordinatesOptions<'drag'> & {
   filterTaps: boolean
+  tapsThreshold: number
   useTouch: boolean
   pointerButtons: number | number[]
   pointerCapture: boolean

--- a/test/config.test.tsx
+++ b/test/config.test.tsx
@@ -76,6 +76,7 @@ describe('testing derived config', () => {
         pointerLock: false,
         pointerCapture: true,
         filterTaps: false,
+        tapsThreshold: 3,
         useTouch: false
       })
     })


### PR DESCRIPTION
Hi there,

I've been using use-gesture for my webxr game development and I've noticed that it's pretty hard to stay under `3 pixels` of `total displacement`. The controllers on the quest 2 for example, are not accurate enough and shake from time to time.

I suggest adding a tapsThreshold so that you're able to increase or decrease the displacement distance manually.

References:
https://use-gesture.netlify.app/docs/options/#filtertaps

Keep in mind; I wasn't able to run the code locally so take this PR as not finished. 