### PR TITLE
fix config passive event test

### DIFF
--- a/test/config.test.tsx
+++ b/test/config.test.tsx
@@ -27,7 +27,7 @@ describe('testing derived config', () => {
         target: document.createElement('div'),
         eventOptions: { passive: false }
       }
-      expect(parse(config)).toHaveProperty('eventOptions.passive', false)
+      expect(parse(config).shared).toHaveProperty('eventOptions.passive', false)
     })
   })
 

--- a/test/config.test.tsx
+++ b/test/config.test.tsx
@@ -27,7 +27,7 @@ describe('testing derived config', () => {
         target: document.createElement('div'),
         eventOptions: { passive: false }
       }
-      expect(config).toHaveProperty('eventOptions.passive', false)
+      expect(parse(config)).toHaveProperty('eventOptions.passive', false)
     })
   })
 


### PR DESCRIPTION
👋 howdy, was browsing and investigating how `eventOptions` works and noticed this test currently validates the newly created `config` object without anything "happening" to `config`.

Looking at the other tests it seems like it should be called with `parse` to validate that the new `eventOptions` are set correctly?