### PR TITLE
Improves preventScroll and delay

### DIFF
--- a/.changeset/tasty-impalas-wave.md
+++ b/.changeset/tasty-impalas-wave.md
@@ -1,0 +1,7 @@
+---
+'@use-gesture/core': patch
+---
+
+- fix: increase `PINCH_WHEEL_RATIO` to `100` to slow down zoom on wheel-based devices.
+- fix: force drag to start no matter the threshold when delay is reached.
+- fix: improve `preventScroll`.

--- a/documentation/gatsby-config.js
+++ b/documentation/gatsby-config.js
@@ -1,4 +1,11 @@
+const title = '@use-gesture documentation'
+const description = `@use-gesture allows you to implement advanced UI interactions with just a few lines of code.`
+
 module.exports = {
+  siteMetadata: {
+    title,
+    description
+  },
   plugins: [
     {
       resolve: 'gatsby-plugin-pnpm',
@@ -9,9 +16,9 @@ module.exports = {
     {
       resolve: 'smooth-doc',
       options: {
-        name: '@use-gesture',
+        name: title,
         siteUrl: 'https://use-gesture.netlify.app',
-        description: `@use-gesture allows you to implement advanced UI interactions with just a few lines of code.`,
+        description,
         author: 'David Bismut',
         sections: ['About', 'Reference', 'More'],
         navItems: [

--- a/documentation/pages/docs/options.mdx
+++ b/documentation/pages/docs/options.mdx
@@ -249,7 +249,7 @@ function DelayExample() {
 }
 ```
 
-> Note that `delay` and `threshold` don't play well together: without moving your pointer, your handler will never get triggered.
+> When using `delay` and `threshold` options at the same time, the drag will start after the delay no matter what.
 
 ### filterTaps
 

--- a/documentation/pages/index.mdx
+++ b/documentation/pages/index.mdx
@@ -1,3 +1,7 @@
+---
+title: Home
+---
+
 import {
   Button,
   HeroSection,

--- a/documentation/src/smooth-doc/styles.css
+++ b/documentation/src/smooth-doc/styles.css
@@ -2,6 +2,13 @@ body.dragged {
   user-select: none;
 }
 
+body.dragged *,
+body.dragged *:after,
+body.dragged *:before {
+  user-select: none;
+  overscroll-behavior: none;
+}
+
 sup {
   margin: 0 0.2em;
 }

--- a/packages/core/src/config/dragConfigResolver.ts
+++ b/packages/core/src/config/dragConfigResolver.ts
@@ -26,7 +26,11 @@ export const dragConfigResolver = {
   },
   preventScrollAxis(this: InternalDragOptions, value: 'x' | 'y' | 'xy', _k: string, { preventScroll }: DragConfig) {
     this.preventScrollDelay =
-      typeof preventScroll === 'number' ? preventScroll : preventScroll ? DEFAULT_PREVENT_SCROLL_DELAY : undefined
+      typeof preventScroll === 'number'
+        ? preventScroll
+        : preventScroll || (preventScroll === undefined && value)
+        ? DEFAULT_PREVENT_SCROLL_DELAY
+        : undefined
     if (!SUPPORT.touchscreen || preventScroll === false) return undefined
     return value ? value : preventScroll !== undefined ? 'y' : undefined
   },

--- a/packages/core/src/config/dragConfigResolver.ts
+++ b/packages/core/src/config/dragConfigResolver.ts
@@ -24,16 +24,11 @@ export const dragConfigResolver = {
     if (SUPPORT.touch) return 'touch'
     return 'mouse'
   },
-  preventScroll(
-    this: InternalDragOptions,
-    value: number | boolean = false,
-    _k: string,
-    { preventScrollAxis = 'y' }: DragConfig
-  ) {
-    this.preventScrollAxis = preventScrollAxis
-    if (!SUPPORT.touchscreen) return false
-    if (typeof value === 'number') return value
-    return value ? DEFAULT_PREVENT_SCROLL_DELAY : false
+  preventScrollAxis(this: InternalDragOptions, value: 'x' | 'y' | 'xy', _k: string, { preventScroll }: DragConfig) {
+    this.preventScrollDelay =
+      typeof preventScroll === 'number' ? preventScroll : preventScroll ? DEFAULT_PREVENT_SCROLL_DELAY : undefined
+    if (!SUPPORT.touchscreen || preventScroll === false) return undefined
+    return value ? value : preventScroll !== undefined ? 'y' : undefined
   },
   pointerCapture(this: InternalDragOptions, _v: any, _k: string, { pointer: { capture = true, buttons = 1 } = {} }) {
     this.pointerButtons = buttons

--- a/packages/core/src/engines/DragEngine.ts
+++ b/packages/core/src/engines/DragEngine.ts
@@ -149,10 +149,12 @@ export class DragEngine extends CoordinatesEngine<'drag'> {
     V.addTo(state._movement, state._delta)
     this.compute(event)
 
-    if (state._delayed) {
+    // if the gesture is delayed but deliberate, then we can start it
+    // immediately.
+    if (state._delayed && state.intentional) {
       this.timeoutStore.remove('dragDelay')
-      // makes sure first is still true when moving for the first time after a
-      // delay
+      // makes sure `first` is still true when moving for the first time after a
+      // delay.
       state.active = false
       this.startPointerDrag(event)
       return

--- a/packages/core/src/engines/DragEngine.ts
+++ b/packages/core/src/engines/DragEngine.ts
@@ -289,7 +289,15 @@ export class DragEngine extends CoordinatesEngine<'drag'> {
 
   setupDelayTrigger(event: PointerEvent) {
     this.state._delayed = true
-    this.timeoutStore.add('dragDelay', this.startPointerDrag.bind(this), this.config.delay, event)
+    this.timeoutStore.add(
+      'dragDelay',
+      () => {
+        // forces drag to start no matter the threshold when delay is reached
+        this.state._step = [0, 0]
+        this.startPointerDrag(event)
+      },
+      this.config.delay
+    )
   }
 
   keyDown(event: KeyboardEvent) {

--- a/packages/core/src/engines/DragEngine.ts
+++ b/packages/core/src/engines/DragEngine.ts
@@ -106,7 +106,7 @@ export class DragEngine extends CoordinatesEngine<'drag'> {
     this.computeValues(pointerValues(event))
     this.computeInitial()
 
-    if (config.preventScroll) {
+    if (config.preventScrollAxis) {
       this.setupScrollPrevention(event)
     } else if (config.delay > 0) {
       this.setupDelayTrigger(event)
@@ -158,7 +158,7 @@ export class DragEngine extends CoordinatesEngine<'drag'> {
       return
     }
 
-    if (config.preventScroll && !state._preventScroll) {
+    if (config.preventScrollAxis && !state._preventScroll) {
       if (state.axis) {
         if (state.axis === config.preventScrollAxis || config.preventScrollAxis === 'xy') {
           state._active = false
@@ -236,11 +236,11 @@ export class DragEngine extends CoordinatesEngine<'drag'> {
 
   setupPointer(event: PointerEvent) {
     const config = this.config
-    let device = config.device
+    const device = config.device
 
     if (process.env.NODE_ENV === 'development') {
       try {
-        if (device === 'pointer') {
+        if (device === 'pointer' && config.preventScrollDelay === undefined) {
           // @ts-ignore (warning for r3f)
           const currentTarget = 'uv' in event ? event.sourceEvent.currentTarget : event.currentTarget
           const style = window.getComputedStyle(currentTarget)
@@ -284,7 +284,7 @@ export class DragEngine extends CoordinatesEngine<'drag'> {
     this.eventStore.add(this.sharedConfig.window!, 'touch', 'change', this.preventScroll.bind(this), { passive: false })
     this.eventStore.add(this.sharedConfig.window!, 'touch', 'end', this.clean.bind(this), { passive: false })
     this.eventStore.add(this.sharedConfig.window!, 'touch', 'cancel', this.clean.bind(this), { passive: false })
-    this.timeoutStore.add('startPointerDrag', this.startPointerDrag.bind(this), this.config.preventScroll, event)
+    this.timeoutStore.add('startPointerDrag', this.startPointerDrag.bind(this), this.config.preventScrollDelay!, event)
   }
 
   setupDelayTrigger(event: PointerEvent) {

--- a/packages/core/src/engines/DragEngine.ts
+++ b/packages/core/src/engines/DragEngine.ts
@@ -282,8 +282,8 @@ export class DragEngine extends CoordinatesEngine<'drag'> {
     persistEvent(event)
     // we add window listeners that will prevent the scroll when the user has started dragging
     this.eventStore.add(this.sharedConfig.window!, 'touch', 'change', this.preventScroll.bind(this), { passive: false })
-    this.eventStore.add(this.sharedConfig.window!, 'touch', 'end', this.clean.bind(this), { passive: false })
-    this.eventStore.add(this.sharedConfig.window!, 'touch', 'cancel', this.clean.bind(this), { passive: false })
+    this.eventStore.add(this.sharedConfig.window!, 'touch', 'end', this.clean.bind(this))
+    this.eventStore.add(this.sharedConfig.window!, 'touch', 'cancel', this.clean.bind(this))
     this.timeoutStore.add('startPointerDrag', this.startPointerDrag.bind(this), this.config.preventScrollDelay!, event)
   }
 

--- a/packages/core/src/engines/DragEngine.ts
+++ b/packages/core/src/engines/DragEngine.ts
@@ -107,6 +107,9 @@ export class DragEngine extends CoordinatesEngine<'drag'> {
     this.computeInitial()
 
     if (config.preventScrollAxis) {
+      // when preventScrollAxis is set we don't consider the gesture active
+      // until it's deliberate
+      state._active = false
       this.setupScrollPrevention(event)
     } else if (config.delay > 0) {
       this.setupDelayTrigger(event)
@@ -199,7 +202,8 @@ export class DragEngine extends CoordinatesEngine<'drag'> {
     const state = this.state
     const config = this.config
 
-    if (!state._pointerActive) return
+    if (!state._active || !state._pointerActive) return
+
     const id = pointerId(event)
     if (state._pointerId !== undefined && id !== state._pointerId) return
 

--- a/packages/core/src/engines/Engine.ts
+++ b/packages/core/src/engines/Engine.ts
@@ -258,7 +258,7 @@ export abstract class Engine<Key extends GestureKey> {
     const { _step, values } = state
 
     if (config.hasCustomTransform) {
-      // When the user is using a custom transform, we're using _step to store
+      // When the user is using a custom transform, we're using `_step` to store
       // the first value passing the threshold.
       if (_step[0] === false) _step[0] = Math.abs(_m0) >= t0 && values[0]
       if (_step[1] === false) _step[1] = Math.abs(_m1) >= t1 && values[1]

--- a/packages/core/src/engines/PinchEngine.ts
+++ b/packages/core/src/engines/PinchEngine.ts
@@ -4,7 +4,7 @@ import { V } from '../utils/maths'
 import { Vector2, WebKitGestureEvent } from '../types'
 
 const SCALE_ANGLE_RATIO_INTENT_DEG = 30
-const PINCH_WHEEL_RATIO = 36
+const PINCH_WHEEL_RATIO = 100
 
 export class PinchEngine extends Engine<'pinch'> {
   ingKey = 'pinching' as const

--- a/packages/core/src/types/internalConfig.ts
+++ b/packages/core/src/types/internalConfig.ts
@@ -32,8 +32,8 @@ export type InternalDragOptions = InternalCoordinatesOptions<'drag'> & {
   tapsThreshold: number
   pointerButtons: number | number[]
   pointerCapture: boolean
-  preventScroll: number
-  preventScrollAxis: 'x' | 'y' | 'xy'
+  preventScrollDelay?: number
+  preventScrollAxis?: 'x' | 'y' | 'xy'
   pointerLock: boolean
   device: 'pointer' | 'touch' | 'mouse'
   swipe: {

--- a/test/config.test.tsx
+++ b/test/config.test.tsx
@@ -70,7 +70,7 @@ describe('testing derived config', () => {
         rubberband: [0, 0],
         axis: undefined,
         lockDirection: false,
-        preventScrollDelay: 250,
+        preventScrollDelay: undefined,
         preventScrollAxis: undefined,
         pointerButtons: 1,
         pointerLock: false,
@@ -140,7 +140,7 @@ describe('testing derived config', () => {
       expect(parse(dragConfig, 'drag').drag).toHaveProperty('preventScrollAxis', 'x')
 
       dragConfig = { preventScrollAxis: 'x', preventScroll: false }
-      expect(parse(dragConfig, 'drag').drag).toHaveProperty('preventScrollDelay', 250)
+      expect(parse(dragConfig, 'drag').drag).toHaveProperty('preventScrollDelay', undefined)
       expect(parse(dragConfig, 'drag').drag).toHaveProperty('preventScrollAxis', undefined)
     })
   })

--- a/test/config.test.tsx
+++ b/test/config.test.tsx
@@ -70,8 +70,8 @@ describe('testing derived config', () => {
         rubberband: [0, 0],
         axis: undefined,
         lockDirection: false,
-        preventScroll: false,
-        preventScrollAxis: 'y',
+        preventScrollDelay: 250,
+        preventScrollAxis: undefined,
         pointerButtons: 1,
         pointerLock: false,
         pointerCapture: true,
@@ -124,6 +124,24 @@ describe('testing derived config', () => {
       dragConfig = { transform }
       expect(parse(dragConfig, 'drag').drag).toHaveProperty('transform', transform)
       expect(parse(dragConfig, 'drag').drag).toHaveProperty('hasCustomTransform', true)
+    })
+
+    test(`derived preventScrollDelay and preventScrollAxis are properly computed`, () => {
+      dragConfig = { preventScroll: true }
+      expect(parse(dragConfig, 'drag').drag).toHaveProperty('preventScrollDelay', 250)
+      expect(parse(dragConfig, 'drag').drag).toHaveProperty('preventScrollAxis', 'y')
+
+      dragConfig = { preventScroll: 300 }
+      expect(parse(dragConfig, 'drag').drag).toHaveProperty('preventScrollDelay', 300)
+      expect(parse(dragConfig, 'drag').drag).toHaveProperty('preventScrollAxis', 'y')
+
+      dragConfig = { preventScrollAxis: 'x' }
+      expect(parse(dragConfig, 'drag').drag).toHaveProperty('preventScrollDelay', 250)
+      expect(parse(dragConfig, 'drag').drag).toHaveProperty('preventScrollAxis', 'x')
+
+      dragConfig = { preventScrollAxis: 'x', preventScroll: false }
+      expect(parse(dragConfig, 'drag').drag).toHaveProperty('preventScrollDelay', 250)
+      expect(parse(dragConfig, 'drag').drag).toHaveProperty('preventScrollAxis', undefined)
     })
   })
 


### PR DESCRIPTION
- fix: increase `PINCH_WHEEL_RATIO` to `100` to slow down zoom on wheel-based devices.
- fix: force drag to start no matter the threshold when delay is reached.
- fix: improve `preventScroll`.