### PR TITLE
fix spelling docs

### DIFF
--- a/documentation/pages/docs/options.mdx
+++ b/documentation/pages/docs/options.mdx
@@ -435,7 +435,7 @@ See the [`swipe`](/docs/state/#swipe) state attribute for more.
 
 <Specs gestures={['drag']} types="number" defaultValue="250" />
 
-A drag gesture lasting moore than `swipe.duration` (in milliseconds) will never be considered a swipe. See the [`swipe`](/docs/state/#swipe) state attribute for more.
+A drag gesture lasting more than `swipe.duration` (in milliseconds) will never be considered a swipe. See the [`swipe`](/docs/state/#swipe) state attribute for more.
 
 ### swipe.velocity
 


### PR DESCRIPTION
Mimicking this feature in `react-swipeable` and noticed this. 😸 
- https://github.com/FormidableLabs/react-swipeable/pull/291