### PR TITLE
Always trigger wheel events on pinch

### DIFF
--- a/.changeset/fresh-pants-knock.md
+++ b/.changeset/fresh-pants-knock.md
@@ -1,0 +1,5 @@
+---
+'@use-gesture/core': major
+---
+
+Always trigger wheel events on pinch

--- a/.changeset/fresh-pants-knock.md
+++ b/.changeset/fresh-pants-knock.md
@@ -1,5 +1,5 @@
 ---
-'@use-gesture/core': major
+'@use-gesture/core': patch
 ---
 
 Always trigger wheel events on pinch

--- a/packages/core/src/engines/PinchEngine.ts
+++ b/packages/core/src/engines/PinchEngine.ts
@@ -289,10 +289,9 @@ export class PinchEngine extends Engine<'pinch'> {
       bindFunction(device, 'end', this[device + 'End'].bind(this))
       // @ts-ignore
       bindFunction(device, 'cancel', this[device + 'End'].bind(this))
-    } else {
-      // we try to set a passive listener, knowing that in any case React will
-      // ignore it.
-      bindFunction('wheel', '', this.wheel.bind(this), { passive: false })
     }
+    // we try to set a passive listener, knowing that in any case React will
+    // ignore it.
+    bindFunction('wheel', '', this.wheel.bind(this), { passive: false })
   }
 }


### PR DESCRIPTION
## Description
This change should allow mouse wheel events to always come through on a pinch gesture regardless of the devices being used.

## Testing
I tested in the gesture-pinch sandbox and it seemed to work as expected on Safari. I tried to create an automated test but was having trouble figuring out the testing framework. I could be wrong, but I also think that the test `using wheel with ctrl key pressed should update pinch distance/angle` in `pinch.test.tsx` is broken. The pinch-da doesn't seem to change after firing the wheel event. You can double check this by copy and pasting the expect before the fireEvent and it will still pass.