### PR TITLE
fix: don't prevent enter key from triggering the onClick event when filterTaps is true

### DIFF
--- a/.changeset/red-games-compare.md
+++ b/.changeset/red-games-compare.md
@@ -1,0 +1,5 @@
+---
+'@use-gesture/core': patch
+---
+
+fix: don't let Enter key preventDefault on onClick when filterTaps is true.

--- a/packages/core/src/engines/DragEngine.ts
+++ b/packages/core/src/engines/DragEngine.ts
@@ -252,7 +252,11 @@ export class DragEngine extends CoordinatesEngine<'drag'> {
   }
 
   pointerClick(event: MouseEvent) {
-    if (!this.state.tap) {
+    // event.detail indicates the number of buttons being pressed. When it's
+    // null, it's likely to be a keyboard event from the Enter Key that could
+    // be used for accessibility, and therefore shouldn't be prevented.
+    // See https://github.com/pmndrs/use-gesture/issues/530
+    if (!this.state.tap && event.detail > 0) {
       event.preventDefault()
       event.stopPropagation()
     }


### PR DESCRIPTION
Fix #530 