### PR TITLE
fix: broken link in docs

### DIFF
--- a/documentation/pages/docs/motivation.mdx
+++ b/documentation/pages/docs/motivation.mdx
@@ -20,7 +20,7 @@ In most situations, `onDrag` becomes as easy to set up as `onMouseMove`. However
 A secondary aspect of <UseGesture /> is to upgrade gestures with additional kinematics attributes, such as **velocity**, **distance**, **delta** and more, that don't come with native browser events.
 
 &zwnj;<UseGesture /> also debounces `scroll`, `wheel` and `move` events, which gives you the capacity to [trigger logic
-when the gesture starts or ends out of the box](/docs/hooks/#start-and-end-handlers).
+when the gesture starts or ends out of the box](/docs/gestures/#start-and-end-handlers).
 
 ## Going further
 


### PR DESCRIPTION
Current link is pointing to old page name `/docs/hooks` instead of `/docs/gestures`.