### PR TITLE
chore(types): use official `NonNullable` again

### DIFF
--- a/packages/core/src/engines/Engine.ts
+++ b/packages/core/src/engines/Engine.ts
@@ -3,7 +3,6 @@ import { getEventDetails } from '../utils/events'
 import { call } from '../utils/fn'
 import { V, computeRubberband } from '../utils/maths'
 import { GestureKey, IngKey, State, Vector2 } from '../types'
-import { NonUndefined } from '../types'
 
 /**
  * The lib doesn't compute the kinematics on the last event of the gesture
@@ -180,7 +179,7 @@ export abstract class Engine<Key extends GestureKey> {
    * Function ran at the start of the gesture.
    * @param event
    */
-  start(event: NonUndefined<State[Key]>['event']) {
+  start(event: NonNullable<State[Key]>['event']) {
     const state = this.state
     const config = this.config
     if (!state._active) {
@@ -223,7 +222,7 @@ export abstract class Engine<Key extends GestureKey> {
    * Computes all sorts of state attributes, including kinematics.
    * @param event
    */
-  compute(event?: NonUndefined<State[Key]>['event']) {
+  compute(event?: NonNullable<State[Key]>['event']) {
     const { state, config, shared } = this
     state.args = this.args
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1,5 +1,5 @@
 import { State } from './state'
-import { Vector2, Target, PointerType, NonUndefined } from './utils'
+import { Vector2, Target, PointerType } from './utils'
 
 export type GestureKey = Exclude<keyof State, 'shared'>
 export type CoordinatesKey = Exclude<GestureKey, 'pinch'>
@@ -42,7 +42,7 @@ export type GestureOptions<T extends GestureKey> = GenericOptions & {
   /**
    * The position `offset` will start from.
    */
-  from?: Vector2 | ((state: NonUndefined<State[T]>) => Vector2)
+  from?: Vector2 | ((state: NonNullable<State[T]>) => Vector2)
   /**
    * The handler will fire only when the gesture displacement is greater than
    * the threshold.

--- a/packages/core/src/types/state.ts
+++ b/packages/core/src/types/state.ts
@@ -1,5 +1,5 @@
 import { GestureKey } from './config'
-import { NonUndefined, Vector2, WebKitGestureEvent } from './utils'
+import { Vector2, WebKitGestureEvent } from './utils'
 
 export type IngKey = 'dragging' | 'wheeling' | 'moving' | 'hovering' | 'scrolling' | 'pinching'
 
@@ -262,4 +262,4 @@ export interface State {
   pinch?: PinchState & { event: EventTypes['pinch'] }
 }
 
-export type FullGestureState<Key extends GestureKey> = SharedGestureState & NonUndefined<State[Key]>
+export type FullGestureState<Key extends GestureKey> = SharedGestureState & NonNullable<State[Key]>

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -3,8 +3,6 @@ export type WebKitGestureEvent = PointerEvent & { scale: number; rotation: numbe
 export type Target = EventTarget | { current: EventTarget | null }
 export type PointerType = 'mouse' | 'touch' | 'pen'
 
-// replaces NonUndefined from 4.7 and inferior versions
-export type NonUndefined<T> = T extends undefined ? never : T
 export type EventHandler<E extends Event = Event> = (event: E) => void
 
 // rip off from React types


### PR DESCRIPTION
This reverts the change to use a custom `NonUndefined`. It was introduced to workaround an issue with TS 4.8 beta:
[TS 4.8-beta playground](https://www.typescriptlang.org/play?ts=4.8.0-beta#code/C4TwDgpgBA4hDOwCuAnCBpCIoF4oHIATFAQwHN8oAfAsASwDsBjAC3wCh3RIoBhAewC2g-gwDKwEsGh4A3lBEA3CIIgNgALigBtBkkEAjCCgA0UPYeMBdKAF8u4aABFSZCVJl8hI8ZOlQAMih5QjpEEmYILV19I1NzWOs7Bx4ABUZWd388AWFRLOgg+QiyABsohMsUZPZGaRQAMxImaALg9igoYnIAfi0XcgKOqHpmFj6odLGh+xToADEkUtK4RFQIAoAeTGwIAA9pBkJ4WARkNB2APlwoADlRW6XSkgNyzYLtHatLzm5oAAkIoRyihtlgoPtDsdTmsLlhrngABTDcLSLQAeUEdGAm0Wy1W5w2fggYJAlzM+AgynU+B+AEpcNcItgaIp+HRCJwmKJEFAAO78FAAaxOSNRFUx2NxTwJ6y2RFctIpVLUwFpDJw11kw25DHg-HKADpSvwyIjxYalCpVXT2LNdbzCPwEOoAOqCoVaQFHEGbBXkWk3c3EjVanU8g0QY2m4MeS38ZSqdS22xAA)

This is no longer an issue with the stable TS 4.8 though so this workaround is no longer needed:
[TS 4.8.4 playground](https://www.typescriptlang.org/play?ts=4.8.4#code/C4TwDgpgBA4hDOwCuAnCBpCIoF4oHIATFAQwHN8oAfAsASwDsBjAC3wCh3RIoBhAewC2g-gwDKwEsGh4A3lBEA3CIIgNgALigBtBkkEAjCCgA0UPYeMBdKAF8u4aABFSZCVJl8hI8ZOlQAMih5QjpEEmYILV19I1NzWOs7Bx4ABUZWd388AWFRLOgg+QiyABsohMsUZPZGaRQAMxImaALg9igoYnIAfi0XcgKOqHpmFj6odLGh+xToADEkUtK4RFQIAoAeTGwIAA9pBkJ4WARkNB2APlwoADlRW6XSkgNyzYLtHatLzm5oAAkIoRyihtlgoPtDsdTmsLlhrngABTDcLSLQAeUEdGAm0Wy1W5w2fggYJAlzM+AgynU+B+AEpcNcItgaIp+HRCJwmKJEFAAO78FAAaxOSNRFUx2NxTwJ6y2RFctIpVLUwFpDJw11kw25DHg-HKADpSvwyIjxYalCpVXT2LNdbzCPwEOoAOqCoVaQFHEGbBXkWk3c3EjVanU8g0QY2m4MeS38ZSqdS22xAA)