### PR TITLE
fix(pinch): cap the movement of wheel events based on the provided bounds

### DIFF
--- a/.changeset/curvy-pens-laugh.md
+++ b/.changeset/curvy-pens-laugh.md
@@ -1,0 +1,5 @@
+---
+'@use-gesture/core': patch
+---
+
+fix: rolls back wheel-based pinch movement to bounds (thanks [@Andarist](https://github.com/Andarist)!)

--- a/packages/core/src/engines/PinchEngine.ts
+++ b/packages/core/src/engines/PinchEngine.ts
@@ -2,6 +2,7 @@ import { Engine } from './Engine'
 import { touchDistanceAngle, distanceAngle, wheelValues } from '../utils/events'
 import { V } from '../utils/maths'
 import { Vector2, WebKitGestureEvent } from '../types'
+import { clampStateInternalMovementToBounds } from '../utils/state'
 
 const SCALE_ANGLE_RATIO_INTENT_DEG = 30
 const PINCH_WHEEL_RATIO = 100
@@ -266,17 +267,7 @@ export class PinchEngine extends Engine<'pinch'> {
     V.addTo(state._movement, state._delta)
 
     // _movement rolls back to when it passed the bounds.
-    const [ox, oy] = state.overflow
-    const [dx, dy] = state._delta
-    const [dirx, diry] = state._direction
-
-    if ((ox < 0 && dx > 0 && dirx < 0) || (ox > 0 && dx < 0 && dirx > 0)) {
-      state._movement[0] = state._movementBound[0] as number
-    }
-
-    if ((oy < 0 && dy > 0 && diry < 0) || (oy > 0 && dy < 0 && diry > 0)) {
-      state._movement[1] = state._movementBound[1] as number
-    }
+    clampStateInternalMovementToBounds(state)
 
     this.state.origin = [event.clientX, event.clientY]
 

--- a/packages/core/src/engines/PinchEngine.ts
+++ b/packages/core/src/engines/PinchEngine.ts
@@ -265,6 +265,19 @@ export class PinchEngine extends Engine<'pinch'> {
     state._delta = [(-wheelValues(event)[1] / PINCH_WHEEL_RATIO) * state.offset[0], 0]
     V.addTo(state._movement, state._delta)
 
+    // _movement rolls back to when it passed the bounds.
+    const [ox, oy] = state.overflow
+    const [dx, dy] = state._delta
+    const [dirx, diry] = state._direction
+
+    if ((ox < 0 && dx > 0 && dirx < 0) || (ox > 0 && dx < 0 && dirx > 0)) {
+      state._movement[0] = state._movementBound[0] as number
+    }
+
+    if ((oy < 0 && dy > 0 && diry < 0) || (oy > 0 && dy < 0 && diry > 0)) {
+      state._movement[1] = state._movementBound[1] as number
+    }
+
     this.state.origin = [event.clientX, event.clientY]
 
     this.compute(event)

--- a/packages/core/src/engines/WheelEngine.ts
+++ b/packages/core/src/engines/WheelEngine.ts
@@ -1,6 +1,7 @@
 import { CoordinatesEngine } from './CoordinatesEngine'
 import { wheelValues } from '../utils/events'
 import { V } from '../utils/maths'
+import { clampStateInternalMovementToBounds } from '../utils/state'
 
 export interface WheelEngine extends CoordinatesEngine<'wheel'> {
   wheel(this: WheelEngine, event: WheelEvent): void
@@ -23,17 +24,7 @@ export class WheelEngine extends CoordinatesEngine<'wheel'> {
     V.addTo(state._movement, state._delta)
 
     // _movement rolls back to when it passed the bounds.
-    const [ox, oy] = state.overflow
-    const [dx, dy] = state._delta
-    const [dirx, diry] = state._direction
-
-    if ((ox < 0 && dx > 0 && dirx < 0) || (ox > 0 && dx < 0 && dirx > 0)) {
-      state._movement[0] = state._movementBound[0] as number
-    }
-
-    if ((oy < 0 && dy > 0 && diry < 0) || (oy > 0 && dy < 0 && diry > 0)) {
-      state._movement[1] = state._movementBound[1] as number
-    }
+    clampStateInternalMovementToBounds(state)
 
     this.compute(event)
     this.emit()

--- a/packages/core/src/utils/state.ts
+++ b/packages/core/src/utils/state.ts
@@ -1,0 +1,19 @@
+import { CommonGestureState } from '../types'
+
+// _movement rolls back to when it passed the bounds.
+/**
+ * @note code is currently used in WheelEngine and PinchEngine.
+ */
+export function clampStateInternalMovementToBounds(state: CommonGestureState) {
+  const [ox, oy] = state.overflow
+  const [dx, dy] = state._delta
+  const [dirx, diry] = state._direction
+
+  if ((ox < 0 && dx > 0 && dirx < 0) || (ox > 0 && dx < 0 && dirx > 0)) {
+    state._movement[0] = state._movementBound[0] as number
+  }
+
+  if ((oy < 0 && dy > 0 && diry < 0) || (oy > 0 && dy < 0 && diry > 0)) {
+    state._movement[1] = state._movementBound[1] as number
+  }
+}


### PR DESCRIPTION
I've noticed that with the code like `scale` is correctly capped:
```ts
  useGesture(
    {
      onPinch: ({ origin: [ox, oy], offset: [scale] }) => {
        // scale is correctly capped to the given bounds
      },
    },
    {
      target: svgRef,
      pinch: {
        scaleBounds: { min: 0.1, max: 10 },
        from: [zoom, 0],
        modifierKey: 'metaKey',
      },
    },
  );
```

However, if we go way outside of the bounds and start going back then nothing happens, for a considerable amount of time. This is because we are not capping the `_movement` in the `wheelChange` within the `PinchEngine`. I think that it makes sense to cap this here, in the same way, that it's done in the `WheelEngine`:
https://github.com/pmndrs/use-gesture/blob/15df8ff071481b6368f8c6365807057bff99b0f6/packages/core/src/engines/WheelEngine.ts#L25-L36

I'm not sure if touch and pointer handlers should also implement the same logic though - so, for now, I left this untouched.