### PR TITLE
lostPointerCapture event cancels pinch gestures

### DIFF
--- a/.changeset/neat-planets-enjoy.md
+++ b/.changeset/neat-planets-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@use-gesture/core': patch
+---
+
+detect lost pointer capture in PinchEngine

--- a/packages/core/src/engines/PinchEngine.ts
+++ b/packages/core/src/engines/PinchEngine.ts
@@ -301,6 +301,8 @@ export class PinchEngine extends Engine<'pinch'> {
       bindFunction(device, 'end', this[device + 'End'].bind(this))
       // @ts-ignore
       bindFunction(device, 'cancel', this[device + 'End'].bind(this))
+      // @ts-ignore
+      bindFunction('lostPointerCapture', '', this[device + 'End'].bind(this))
     }
     // we try to set a passive listener, knowing that in any case React will
     // ignore it.


### PR DESCRIPTION
Hello 👋🏼 

At [tldraw](https://github.com/tldraw/tldraw) we use `use-gesture` for our canvas interactions. We recently noticed one situation where we use a long press on our canvas (the gesture target elem) to open a context menu. In iOS safari, this was firing a `pointerdown` event on the canvas and a `pointerup` event on the context menu. This left the `PinchEngine` in a broken state where it thought that the pointer was still down because it never received the `pointerup` event.

I noticed that you use the `lostpointercapture` event in the `DragEngine` to handle precisely this kind of situation, and it seems to work for the `PinchEngine` too. At least in our case.

I'd normally add tests for a PR like this, but I ran into problems with your test setup and it seems like a rabbit hole to figure out so I didn't add any tests yet. Please let me know if you'd like me to dig in and figure that out.