### PR TITLE
fix(types): compatibility with @types/react >=18.2.66

### DIFF
--- a/.changeset/stale-seahorses-speak.md
+++ b/.changeset/stale-seahorses-speak.md
@@ -1,0 +1,5 @@
+---
+"@use-gesture/core": patch
+---
+
+fix(types): compatibility with @types/react >=18.2.66

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -165,9 +165,7 @@ export interface DOMHandlers {
   onPointerCancel?: EventHandler<PointerEvent>
   onPointerCancelCapture?: EventHandler<PointerEvent>
   onPointerEnter?: EventHandler<PointerEvent>
-  onPointerEnterCapture?: EventHandler<PointerEvent>
   onPointerLeave?: EventHandler<PointerEvent>
-  onPointerLeaveCapture?: EventHandler<PointerEvent>
   onPointerOver?: EventHandler<PointerEvent>
   onPointerOverCapture?: EventHandler<PointerEvent>
   onPointerOut?: EventHandler<PointerEvent>


### PR DESCRIPTION
Fixes #654.

The `onPointerEnterCapture` and `onPointerLeaveCapture` events were removed from `@types/react` in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68984, which causes the type error shown in the above issue.

This PR fixes the type error by removing those events from use-gesture's `DOMHandlers` type.