### PR TITLE
Fix docs: `from` instead of `initial`

### DIFF
--- a/documentation/pages/docs/state.mdx
+++ b/documentation/pages/docs/state.mdx
@@ -119,7 +119,7 @@ function OffsetExample() {
 
 ### memo
 
-`memo` stores the value returned by the previous call of your handler. The most common usecase for using `memo` should be simplified by using [`initial`](/docs/options/#initial).
+`memo` stores the value returned by the previous call of your handler. The most common usecase for using `memo` should be simplified by using [`from`](/docs/options/#from).
 
 ### cancel
 


### PR DESCRIPTION
I tried following the link to `initial` from [`memo`](https://use-gesture.netlify.app/docs/state/#memo) and it’s broken. I found `from` and that seems to be the intended option/link.