### PR TITLE
Add `gestureKey` to state

### DIFF
--- a/.changeset/vast-peaches-listen.md
+++ b/.changeset/vast-peaches-listen.md
@@ -1,0 +1,7 @@
+---
+'@use-gesture/core': minor
+'@use-gesture/react': minor
+'@use-gesture/vanilla': minor
+---
+
+feat(core): Add `gestureKey` to the `state`

--- a/documentation/pages/docs/state.mdx
+++ b/documentation/pages/docs/state.mdx
@@ -52,6 +52,7 @@ const bind = useXXXX(state => {
     buttons,       // number of buttons pressed
     touches,       // number of fingers touching the screen
     args,          // arguments you passed to bind (React only)
+    gestureKey,    // identifier for the gesture type currently active
     ctrlKey,       // true when control key is pressed
     altKey,        // "      "  alt     "      "
     shiftKey,      // "      "  shift   "      "

--- a/packages/core/src/engines/Engine.ts
+++ b/packages/core/src/engines/Engine.ts
@@ -1,9 +1,8 @@
 import { Controller } from '../Controller'
+import { GestureKey, IngKey, NonUndefined, State, Vector2 } from '../types'
 import { getEventDetails } from '../utils/events'
 import { call } from '../utils/fn'
 import { V, computeRubberband } from '../utils/maths'
-import { GestureKey, IngKey, State, Vector2 } from '../types'
-import { NonUndefined } from '../types'
 
 /**
  * The lib doesn't compute the kinematics on the last event of the gesture
@@ -74,7 +73,9 @@ export abstract class Engine<Key extends GestureKey> {
     this.key = key
 
     if (!this.state) {
-      this.state = {} as any
+      this.state = {
+        gestureKey: key
+      } as any
       this.computeValues([0, 0])
       this.computeInitial()
 

--- a/packages/core/src/types/state.ts
+++ b/packages/core/src/types/state.ts
@@ -181,6 +181,13 @@ export type CommonGestureState = {
   args?: any
 }
 
+export type CommonGestureKey = {
+  /**
+   * The gesture type.
+   */
+  gestureKey: 'wheel' | 'scroll' | 'move' | 'hover'
+}
+
 export type CoordinatesState = CommonGestureState & {
   /**
    * The initial axis (x or y) of the gesture.
@@ -215,6 +222,10 @@ export type DragState = CoordinatesState & {
    * [swipeX, swipeY] is [0, 0] if no swipe detected, -1 or 1 otherwise.
    */
   swipe: Vector2
+  /**
+   * The gesture type.
+   */
+  gestureKey: 'drag'
 }
 
 export interface PinchState extends CommonGestureState {
@@ -245,6 +256,10 @@ export interface PinchState extends CommonGestureState {
    * Function that can be called to cancel the pinch.
    */
   cancel(): void
+  /**
+   * The gesture type.
+   */
+  gestureKey: 'pinch'
 }
 
 export type EventTypes = {
@@ -259,10 +274,10 @@ export type EventTypes = {
 export interface State {
   shared: SharedGestureState
   drag?: DragState & { event: EventTypes['drag'] }
-  wheel?: CoordinatesState & { event: EventTypes['wheel'] }
-  scroll?: CoordinatesState & { event: EventTypes['scroll'] }
-  move?: CoordinatesState & { event: EventTypes['move'] }
-  hover?: CoordinatesState & { event: EventTypes['hover'] }
+  wheel?: CoordinatesState & CommonGestureKey & { event: EventTypes['wheel'] }
+  scroll?: CoordinatesState & CommonGestureKey & { event: EventTypes['scroll'] }
+  move?: CoordinatesState & CommonGestureKey & { event: EventTypes['move'] }
+  hover?: CoordinatesState & CommonGestureKey & { event: EventTypes['hover'] }
   pinch?: PinchState & { event: EventTypes['pinch'] }
 }
 


### PR DESCRIPTION
This would allow reusing the same callback without a typescript error by differentiating `drag`, `pinch` and all other states.

This PR adds a new `gestureKey` property to the `state`.

```tsx
  const callback = (
    state: Required<State>['drag' |  'move']
  ) => {
    if (state.gestureKey === 'drag') {
      // This is ok!
      console.log(state.tap)
    }
    // Property `tap` does not exist on type
    console.log(state.tap)
  }

  const bind = useGesture({
    onDrag: callback,
    onMove: callback
  })
```