### PR TITLE
docs: update readme links to point to working project page

### DIFF
--- a/.changeset/update-readme-links.md
+++ b/.changeset/update-readme-links.md
@@ -1,0 +1,6 @@
+---
+"@use-gesture/react": patch
+"@use-gesture/vanilla": patch
+---
+
+Updated README documentation links from netlify.com to netlify.app domain

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ yarn add @use-gesture/vanilla
 npm install @use-gesture/vanilla
 ```
 
-### [Full documentation website](https://use-gesture.netlify.com)
+### [Full documentation website](https://use-gesture.netlify.app)
 
-- [Available Gestures](https://use-gesture.netlify.com/docs/gestures)
-- [Gesture State](https://use-gesture.netlify.com/docs/state)
-- [Gesture Options](https://use-gesture.netlify.com/docs/options)
-- [FAQ](https://use-gesture.netlify.com/docs/faq)
+- [Available Gestures](https://use-gesture.netlify.app/docs/gestures)
+- [Gesture State](https://use-gesture.netlify.app/docs/state)
+- [Gesture Options](https://use-gesture.netlify.app/docs/options)
+- [FAQ](https://use-gesture.netlify.app/docs/faq)
 
 ### Simple example
 


### PR DESCRIPTION
change the links in the README to point to correct website:

<img width="570" height="504" alt="Screenshot 2025-11-01 at 15 29 34" src="https://github.com/user-attachments/assets/25f8598e-e659-425b-beab-6f4bddfc5829" />
