### PR TITLE
feat(tap): add tap gesture with single/double tap and long press discrimination

### DIFF
--- a/.changeset/tap-gesture-feature.md
+++ b/.changeset/tap-gesture-feature.md
@@ -1,0 +1,32 @@
+---
+"@use-gesture/core": minor
+"@use-gesture/react": minor
+"@use-gesture/vanilla": minor
+---
+
+Add tap gesture with single/double tap and long press discrimination
+
+New tap gesture provides discrimination between single taps, double taps, and long presses:
+
+- **singleTap** - Confirmed after `tapTimeout` (180ms) with no second tap
+- **doubleTap** - Two taps within `tapTimeout` window
+- **longPress** - Pointer held for `longPressTimeout` ms
+- **tapCount** - Number of taps detected (1 or 2)
+
+Configuration options:
+- `tapDiscrimination` - Enable single/double tap discrimination (default: true)
+- `tapTimeout` - Max time between taps for double tap (default: 180ms)
+- `longPressTimeout` - Time to trigger long press (default: 0 = disabled)
+- `moveThreshold` - Max movement before tap is canceled (default: 10px)
+
+Usage:
+```tsx
+// React
+import { useTap } from '@use-gesture/react'
+
+const bind = useTap(({ singleTap, doubleTap, longPress, tapCount }) => {
+  if (singleTap) console.log('single tap')
+  if (doubleTap) console.log('double tap')
+  if (longPress) console.log('long press')
+})
+```

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -9,6 +9,7 @@
     "/demo/src/sandboxes/gesture-pinch",
     "/demo/src/sandboxes/gesture-pinch-multiple",
     "/demo/src/sandboxes/gesture-three",
+    "/demo/src/sandboxes/gesture-tap",
     "/demo/src/sandboxes/card-zoom",
     "/demo/src/sandboxes/viewpager"
   ],

--- a/demo/src/App.jsx
+++ b/demo/src/App.jsx
@@ -27,6 +27,7 @@ import InfiniteSlideshow from './sandboxes/infinite-slideshow/src/App'
 import ActionSheet from './sandboxes/action-sheet/src/App'
 import DotsConnect from './sandboxes/dots-connect/src/App'
 import NativeVsLib from './sandboxes/native-vs-lib/src/App'
+import Tap from './sandboxes/gesture-tap/src/App'
 
 const links = {
   'gesture-simplest': Simplest,
@@ -42,6 +43,7 @@ const links = {
   'gesture-three-prevent-scroll': ThreePreventScroll,
   'gesture-scroll': Scroll,
   'gesture-wheel': Wheel,
+  'gesture-tap': Tap,
   slide: Slide,
   'draggable-list': DraggableList,
   'draggable-image': DraggableImage,

--- a/demo/src/sandboxes/gesture-tap/package.json
+++ b/demo/src/sandboxes/gesture-tap/package.json
@@ -6,6 +6,7 @@
     "@leva-ui/plugin-spring": "*",
     "@react-spring/web": "^9.4.5",
     "@use-gesture/react": "latest",
+    "leva": "*",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-scripts": "^5.0.1"

--- a/demo/src/sandboxes/gesture-tap/package.json
+++ b/demo/src/sandboxes/gesture-tap/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "gesture-tap",
+  "version": "1.0.0",
+  "main": "src/index.jsx",
+  "dependencies": {
+    "@leva-ui/plugin-spring": "*",
+    "@react-spring/web": "^9.4.5",
+    "@use-gesture/react": "latest",
+    "react": "^18.1.0",
+    "react-dom": "^18.1.0",
+    "react-scripts": "^5.0.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ],
+  "devDependencies": {
+    "@types/lodash-es": "^4.17.4",
+    "@types/react": "^18.0.3",
+    "@types/react-dom": "^18.0.0",
+    "typescript": "^4.9.4",
+    "typescript-plugin-css-modules": "^4.1.1"
+  }
+}

--- a/demo/src/sandboxes/gesture-tap/public/index.html
+++ b/demo/src/sandboxes/gesture-tap/public/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="theme-color" content="#000000" />
+    <title>Use-Gesture Tap Sandbox</title>
+  </head>
+
+  <body>
+    <noscript> You need to enable JavaScript to run this app. </noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/demo/src/sandboxes/gesture-tap/src/App.jsx
+++ b/demo/src/sandboxes/gesture-tap/src/App.jsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import { useTap } from '@use-gesture/react'
+import { a, useSpring } from '@react-spring/web'
+import { useControls } from 'leva'
+
+import styles from './styles.module.css'
+
+function Tappable() {
+  const [gestureType, setGestureType] = React.useState('none')
+  const [tapCount, setTapCount] = React.useState(0)
+
+  const { tapDiscrimination, tapTimeout, longPressTimeout, moveThreshold } = useControls({
+    tapDiscrimination: true,
+    tapTimeout: { value: 250, step: 50, min: 100, max: 500 },
+    longPressTimeout: { value: 500, step: 100, min: 200, max: 1000 },
+    moveThreshold: { value: 10, step: 5, min: 5, max: 50 }
+  })
+
+  const [style, api] = useSpring(() => ({ scale: 1, backgroundColor: '#ec625c' }))
+
+  const bind = useTap(
+    ({ singleTap, doubleTap, longPress, tapCount: count, xy, tapping }) => {
+      setTapCount(count)
+
+      if (longPress) {
+        setGestureType('longPress')
+        api.start({ scale: 1.3, backgroundColor: '#f472b6' })
+        setTimeout(() => {
+          api.start({ scale: 1, backgroundColor: '#ec625c' })
+        }, 300)
+      } else if (doubleTap) {
+        setGestureType('doubleTap')
+        api.start({ scale: 1.2, backgroundColor: '#60a5fa' })
+        setTimeout(() => {
+          api.start({ scale: 1, backgroundColor: '#ec625c' })
+        }, 300)
+      } else if (singleTap) {
+        setGestureType('singleTap')
+        api.start({ scale: 0.9, backgroundColor: '#4ade80' })
+        setTimeout(() => {
+          api.start({ scale: 1, backgroundColor: '#ec625c' })
+        }, 150)
+      }
+
+      // Reset after showing feedback
+      if (singleTap || doubleTap || longPress) {
+        setTimeout(() => setGestureType('none'), 1000)
+      }
+    },
+    {
+      tapDiscrimination,
+      tapTimeout,
+      longPressTimeout,
+      moveThreshold
+    }
+  )
+
+  const getLabel = () => {
+    if (gestureType === 'singleTap') return 'Single Tap!'
+    if (gestureType === 'doubleTap') return 'Double Tap!'
+    if (gestureType === 'longPress') return 'Long Press!'
+    return 'Tap me'
+  }
+
+  return (
+    <>
+      <a.div tabIndex={-1} {...bind()} className={`${styles.tap} ${styles[gestureType]}`} style={style}>
+        <div>
+          <span>{getLabel()}</span>
+          <span>count: {tapCount}</span>
+        </div>
+      </a.div>
+      <div className={styles.status}>
+        <span>Single Tap: {gestureType === 'singleTap' ? '✓' : '-'}</span>
+        <span>Double Tap: {gestureType === 'doubleTap' ? '✓' : '-'}</span>
+        <span>Long Press: {gestureType === 'longPress' ? '✓' : '-'}</span>
+      </div>
+      <div className={styles.info}>
+        <p>Try: single tap, double tap, or hold for long press</p>
+        <p>Use Leva controls to adjust timing thresholds</p>
+      </div>
+    </>
+  )
+}
+
+export default function App() {
+  return (
+    <div className="flex fill center">
+      <Tappable />
+    </div>
+  )
+}

--- a/demo/src/sandboxes/gesture-tap/src/index.css
+++ b/demo/src/sandboxes/gesture-tap/src/index.css
@@ -1,0 +1,14 @@
+html,
+body,
+#root {
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}

--- a/demo/src/sandboxes/gesture-tap/src/index.jsx
+++ b/demo/src/sandboxes/gesture-tap/src/index.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+
+import './index.css'
+
+const rootElement = document.getElementById('root')
+const root = createRoot(rootElement)
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/demo/src/sandboxes/gesture-tap/src/styles.module.css
+++ b/demo/src/sandboxes/gesture-tap/src/styles.module.css
@@ -1,0 +1,71 @@
+.tap {
+  position: absolute;
+  height: 120px;
+  width: 120px;
+  background-color: #ec625c;
+  cursor: pointer;
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+  border-radius: 8px;
+}
+
+.tap > div {
+  margin: 10%;
+  width: 80%;
+  height: 80%;
+  background-color: #000;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-family: monospace;
+  font-size: 11px;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.tap:focus {
+  outline: 2px solid #fff;
+}
+
+.tap.singleTap > div {
+  background-color: #4ade80;
+}
+
+.tap.doubleTap > div {
+  background-color: #60a5fa;
+}
+
+.tap.longPress > div {
+  background-color: #f472b6;
+}
+
+.status {
+  position: absolute;
+  bottom: 100px;
+  color: #888;
+  font-family: monospace;
+  font-size: 14px;
+  text-align: center;
+}
+
+.status span {
+  display: block;
+  margin: 4px 0;
+}
+
+.info {
+  position: absolute;
+  bottom: 40px;
+  color: #888;
+  font-family: monospace;
+  font-size: 11px;
+  text-align: center;
+  max-width: 300px;
+}
+
+.info p {
+  margin: 4px 0;
+}

--- a/package.json
+++ b/package.json
@@ -113,5 +113,6 @@
   "lint-staged": {
     "*.js": "eslint --cache --fix",
     "*.{js,css,md}": "prettier --write"
-  }
+  },
+  "packageManager": "pnpm@8.7.5"
 }

--- a/packages/core/src/Controller.ts
+++ b/packages/core/src/Controller.ts
@@ -6,6 +6,9 @@ import { TimeoutStore } from './TimeoutStore'
 import { chain } from './utils/fn'
 import { GestureKey, InternalConfig, InternalHandlers, NativeHandlers, State, UserGestureConfig } from './types'
 
+/**
+ * The Controller class is responsible for managing the state of gestures.
+ */
 export class Controller {
   /**
    * The list of gestures handled by the Controller.
@@ -163,6 +166,7 @@ function resolveGestures(ctrl: Controller, internalHandlers: InternalHandlers) {
   if (internalHandlers.move) setupGesture(ctrl, 'move')
   if (internalHandlers.pinch) setupGesture(ctrl, 'pinch')
   if (internalHandlers.hover) setupGesture(ctrl, 'hover')
+  if (internalHandlers.tap) setupGesture(ctrl, 'tap')
 }
 
 const bindToProps =

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -19,6 +19,9 @@ import { wheelConfigResolver } from './config/wheelConfigResolver'
 import { HoverEngine } from './engines/HoverEngine'
 import { hoverConfigResolver } from './config/hoverConfigResolver'
 
+import { TapEngine } from './engines/TapEngine'
+import { tapConfigResolver } from './config/tapConfigResolver'
+
 export const EngineMap = new Map<GestureKey, EngineClass<any>>()
 export const ConfigResolverMap = new Map<GestureKey, ResolverMap>()
 
@@ -61,4 +64,10 @@ export const wheelAction: Action = {
   key: 'wheel',
   engine: WheelEngine as any,
   resolver: wheelConfigResolver
+}
+
+export const tapAction: Action = {
+  key: 'tap',
+  engine: TapEngine as any,
+  resolver: tapConfigResolver
 }

--- a/packages/core/src/config/tapConfigResolver.ts
+++ b/packages/core/src/config/tapConfigResolver.ts
@@ -1,5 +1,9 @@
 import { commonConfigResolver } from './commonConfigResolver'
 
+export const DEFAULT_TAP_TIMEOUT = 180
+export const DEFAULT_LONG_PRESS_TIMEOUT = 0
+export const DEFAULT_TAP_MOVE_THRESHOLD = 10
+
 export const tapConfigResolver = {
   ...commonConfigResolver,
   // CoordinatesEngine compatibility - tap doesn't use axis locking
@@ -15,13 +19,13 @@ export const tapConfigResolver = {
   tapDiscrimination(value = false) {
     return value
   },
-  tapTimeout(value = 300) {
+  tapTimeout(value = DEFAULT_TAP_TIMEOUT) {
     return value
   },
-  longPressTimeout(value = 0) {
+  longPressTimeout(value = DEFAULT_LONG_PRESS_TIMEOUT) {
     return value
   },
-  moveThreshold(value = 10) {
+  moveThreshold(value = DEFAULT_TAP_MOVE_THRESHOLD) {
     return value
   },
   mouseOnly(value = true) {

--- a/packages/core/src/config/tapConfigResolver.ts
+++ b/packages/core/src/config/tapConfigResolver.ts
@@ -1,0 +1,36 @@
+import { commonConfigResolver } from './commonConfigResolver'
+
+export const tapConfigResolver = {
+  ...commonConfigResolver,
+  // CoordinatesEngine compatibility - tap doesn't use axis locking
+  axis(_value?: undefined): undefined {
+    return undefined
+  },
+  axisThreshold(_value = 0) {
+    return 0
+  },
+  lockDirection(_value = false) {
+    return false
+  },
+  tapDiscrimination(value = false) {
+    return value
+  },
+  tapTimeout(value = 300) {
+    return value
+  },
+  longPressTimeout(value = 0) {
+    return value
+  },
+  moveThreshold(value = 10) {
+    return value
+  },
+  mouseOnly(value = true) {
+    return value
+  },
+  pointerButtons(value: number | number[] | -1 = 1) {
+    return value
+  },
+  pointerCapture(value = true) {
+    return value
+  }
+}

--- a/packages/core/src/engines/TapEngine.ts
+++ b/packages/core/src/engines/TapEngine.ts
@@ -1,0 +1,217 @@
+import { CoordinatesEngine } from './CoordinatesEngine'
+import { pointerId, pointerValues } from '../utils/events'
+
+export class TapEngine extends CoordinatesEngine<'tap'> {
+  ingKey = 'tapping' as const
+
+  init() {
+    super.init()
+    const state = this.state as any
+    state._pointerId = undefined
+    state._pointerActive = false
+    state._waitingForSecondTap = false
+    state._longPressTriggered = false
+    state.tapCount = 0
+    state.singleTap = false
+    state.doubleTap = false
+    state.longPress = false
+    state._lastUpTime = 0
+    state._initialXY = [0, 0]
+  }
+
+  reset() {
+    super.reset()
+    const state = this.state as any
+    state._pointerId = undefined
+    state._pointerActive = false
+    state._waitingForSecondTap = false
+    state._longPressTriggered = false
+    state.tapCount = 0
+    state.singleTap = false
+    state.doubleTap = false
+    state.longPress = false
+    state._lastUpTime = 0
+  }
+
+  computeOffset() {
+    // Tap doesn't track offset
+  }
+
+  computeMovement() {
+    // Tap doesn't track movement in the traditional sense
+  }
+
+  pointerDown(event: PointerEvent) {
+    const config = this.config as any
+    const state = this.state as any
+
+    // Check pointer buttons
+    if (
+      event.buttons != null &&
+      (Array.isArray(config.pointerButtons)
+        ? !config.pointerButtons.includes(event.buttons)
+        : config.pointerButtons !== -1 && config.pointerButtons !== event.buttons)
+    ) {
+      return
+    }
+
+    // Ignore touch if mouseOnly is true
+    if (config.mouseOnly && event.pointerType !== 'mouse') return
+
+    this.start(event)
+
+    // Setup pointer capture
+    if (config.pointerCapture) {
+      ;(event.target as HTMLElement).setPointerCapture(event.pointerId)
+    }
+
+    // Store initial position for movement threshold check
+    state._initialXY = [event.clientX, event.clientY]
+
+    state._pointerId = pointerId(event)
+    state._pointerActive = true
+    state._longPressTriggered = false
+    state.longPress = false
+
+    // Setup long press timeout
+    if (config.longPressTimeout > 0) {
+      this.timeoutStore.add(
+        'longPress',
+        () => {
+          if (state._pointerActive) {
+            state._longPressTriggered = true
+            state.longPress = true
+            state._active = true
+            this.compute(event)
+            this.emit()
+          }
+        },
+        config.longPressTimeout
+      )
+    }
+
+    // Cancel pending single tap confirmation if second tap comes quickly
+    if (state._waitingForSecondTap) {
+      this.timeoutStore.remove('tapDiscrimination')
+    }
+
+    this.computeValues(pointerValues(event))
+    this.computeInitial()
+
+    // Set intentional to true and emit so tapping state is available
+    state._active = true
+    state.intentional = true
+    this.compute(event)
+    this.emit()
+  }
+
+  pointerMove(event: PointerEvent) {
+    const state = this.state as any
+    const config = this.config as any
+
+    if (!state._pointerActive || state._pointerId !== pointerId(event)) return
+
+    // Check if movement exceeds threshold - if so, cancel the tap
+    const dx = Math.abs(event.clientX - state._initialXY[0])
+    const dy = Math.abs(event.clientY - state._initialXY[1])
+
+    if (dx > config.moveThreshold || dy > config.moveThreshold) {
+      this.cancel()
+    }
+  }
+
+  pointerUp(event: PointerEvent) {
+    const state = this.state as any
+    const config = this.config as any
+    const eventPointerId = pointerId(event)
+
+    // Cancel long press timeout
+    this.timeoutStore.remove('longPress')
+
+    if (!state._pointerActive || state._pointerId !== eventPointerId) return
+
+    state._pointerActive = false
+    state.xy = [event.clientX, event.clientY]
+    state.values = state.xy
+
+    // If long press was triggered, don't fire tap
+    if (state._longPressTriggered) {
+      this.clean()
+      return
+    }
+
+    // Handle tap discrimination
+    if (config.tapDiscrimination) {
+      const now = event.timeStamp
+      const timeSinceLastUp = now - state._lastUpTime
+
+      if (timeSinceLastUp <= config.tapTimeout && state.tapCount === 1) {
+        // Double tap detected
+        state.tapCount = 2
+        state.doubleTap = true
+        state.singleTap = false
+        state._waitingForSecondTap = false
+        this.timeoutStore.remove('tapDiscrimination')
+        state._active = false // Set to false to signal gesture ending
+        state.intentional = true
+        state._force = true
+        this.compute(event)
+        this.emit()
+        this.clean()
+      } else {
+        // First tap - wait to confirm single
+        state.tapCount = 1
+        state._waitingForSecondTap = true
+        state._lastUpTime = now
+
+        this.timeoutStore.add(
+          'tapDiscrimination',
+          () => {
+            if (state.tapCount === 1) {
+              state.singleTap = true
+              state._waitingForSecondTap = false
+              state._active = false // Set to false to signal gesture ending
+              state.intentional = true
+              state._force = true
+              this.compute(event)
+              this.emit()
+              this.clean()
+            }
+          },
+          config.tapTimeout
+        )
+        // Don't call clean() here - it would clear the timeout we just set
+        // Only clean event store, not timeout store
+        this.eventStore.clean()
+      }
+    } else {
+      // No discrimination - immediate tap
+      state.tapCount = 1
+      state._active = false // Set to false to signal gesture ending
+      state.intentional = true
+      state._force = true
+      this.compute(event)
+      this.emit()
+      this.clean()
+    }
+  }
+
+  cancel() {
+    const state = this.state as any
+    if (state.canceled) return
+    state.canceled = true
+    this.timeoutStore.remove('longPress')
+    this.timeoutStore.remove('tapDiscrimination')
+    state._pointerActive = false
+    state._waitingForSecondTap = false
+    state._active = false
+    this.compute()
+    this.emit()
+  }
+
+  bind(bindFunction: any) {
+    bindFunction('pointer', 'down', this.pointerDown.bind(this))
+    bindFunction('pointer', 'move', this.pointerMove.bind(this))
+    bindFunction('pointer', 'up', this.pointerUp.bind(this))
+  }
+}

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -1,7 +1,7 @@
 import { FullGestureState, GestureHandlers, GestureKey, InternalHandlers, UserGestureConfig } from './types'
 import { EngineMap } from './actions'
 
-const RE_NOT_NATIVE = /^on(Drag|Wheel|Scroll|Move|Pinch|Hover)/
+const RE_NOT_NATIVE = /^on(Drag|Wheel|Scroll|Move|Pinch|Hover|Tap)/
 
 function sortHandlers(_handlers: GestureHandlers) {
   const native: any = {}
@@ -22,7 +22,7 @@ function sortHandlers(_handlers: GestureHandlers) {
   return [handlers, native, actions]
 }
 
-type HandlerKey = 'onDrag' | 'onPinch' | 'onWheel' | 'onMove' | 'onScroll' | 'onHover'
+type HandlerKey = 'onDrag' | 'onPinch' | 'onWheel' | 'onMove' | 'onScroll' | 'onHover' | 'onTap'
 
 function registerGesture(
   actions: Set<unknown>,
@@ -73,6 +73,7 @@ export function parseMergedHandlers(mergedHandlers: GestureHandlers, mergedConfi
   registerGesture(actions, handlers, 'onPinch', 'pinch', internalHandlers, mergedConfig)
   registerGesture(actions, handlers, 'onMove', 'move', internalHandlers, mergedConfig)
   registerGesture(actions, handlers, 'onHover', 'hover', internalHandlers, mergedConfig)
+  registerGesture(actions, handlers, 'onTap', 'tap', internalHandlers, mergedConfig)
 
   return { handlers: internalHandlers, config: mergedConfig, nativeHandlers }
 }

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -140,6 +140,43 @@ export type MoveConfig = CoordinatesConfig<'move'> & MoveAndHoverMouseOnly
 
 export type HoverConfig = MoveAndHoverMouseOnly
 
+export type TapConfig = GenericOptions & {
+  /**
+   * Enables single vs double tap discrimination.
+   * When true, singleTap fires after tapTimeout if no second tap occurs.
+   * @default false
+   */
+  tapDiscrimination?: boolean
+  /**
+   * Maximum time in ms between two taps to be considered a double tap.
+   * @default 300
+   */
+  tapTimeout?: number
+  /**
+   * Time in ms that pointer must be held down to trigger a long press.
+   * Set to 0 to disable long press detection.
+   * @default 0
+   */
+  longPressTimeout?: number
+  /**
+   * Maximum movement in pixels before the tap is canceled.
+   * @default 10
+   */
+  moveThreshold?: number
+  /**
+   * If false, tap handlers will also fire on touch devices.
+   */
+  mouseOnly?: boolean
+  /**
+   * The pointer buttons that trigger the tap.
+   */
+  pointerButtons?: number | number[] | -1
+  /**
+   * If true, pointer capture will be set on pointer down.
+   */
+  pointerCapture?: boolean
+}
+
 export type DragConfig = Omit<CoordinatesConfig<'drag'>, 'axisThreshold' | 'bounds'> & {
   /**
    * If true, the component won't trigger your drag logic if the user just clicked on the component.
@@ -239,6 +276,7 @@ export type UserWheelConfig = GenericOptions & CoordinatesConfig<'wheel'>
 export type UserScrollConfig = GenericOptions & CoordinatesConfig<'scroll'>
 export type UserMoveConfig = GenericOptions & MoveConfig
 export type UserHoverConfig = GenericOptions & HoverConfig
+export type UserTapConfig = GenericOptions & TapConfig
 
 export type UserGestureConfig = GenericOptions & {
   drag?: DragConfig
@@ -247,4 +285,5 @@ export type UserGestureConfig = GenericOptions & {
   move?: MoveConfig
   pinch?: PinchConfig
   hover?: { enabled?: boolean } & HoverConfig
+  tap?: TapConfig
 }

--- a/packages/core/src/types/handlers.ts
+++ b/packages/core/src/types/handlers.ts
@@ -27,6 +27,9 @@ export type UserHandlers<T extends AnyHandlerEventTypes = EventTypes> = {
   onScrollStart: Handler<'scroll', check<T, 'scroll'>>
   onScrollEnd: Handler<'scroll', check<T, 'scroll'>>
   onHover: Handler<'hover', check<T, 'hover'>>
+  onTap: Handler<'tap', check<T, 'tap'>>
+  onTapStart: Handler<'tap', check<T, 'tap'>>
+  onTapEnd: Handler<'tap', check<T, 'tap'>>
 }
 
 type NativeHandlersKeys = keyof Omit<DOMHandlers, keyof UserHandlers>
@@ -51,6 +54,7 @@ export type AnyHandlerEventTypes = Partial<
     move: any
     pinch: any
     hover: any
+    tap: any
   } & { [key in NativeHandlersKeys]: any }
 >
 

--- a/packages/core/src/types/internalConfig.ts
+++ b/packages/core/src/types/internalConfig.ts
@@ -63,6 +63,20 @@ type MoveAndHoverMouseOnly = {
   mouseOnly: boolean
 }
 
+export type InternalTapOptions = InternalGestureOptions<'tap'> & {
+  tapDiscrimination: boolean
+  tapTimeout: number
+  longPressTimeout: number
+  moveThreshold: number
+  mouseOnly: boolean
+  pointerButtons: number | number[]
+  pointerCapture: boolean
+  // CoordinatesEngine compatibility (tap doesn't use these but needs them for type compatibility)
+  axis?: undefined
+  lockDirection: boolean
+  axisThreshold: number
+}
+
 export type InternalConfig = {
   shared: InternalGenericOptions
   drag?: InternalDragOptions
@@ -71,4 +85,5 @@ export type InternalConfig = {
   move?: InternalCoordinatesOptions<'move'> & MoveAndHoverMouseOnly
   hover?: InternalCoordinatesOptions<'hover'> & MoveAndHoverMouseOnly
   pinch?: InternalPinchOptions
+  tap?: InternalTapOptions
 }

--- a/packages/core/src/types/state.ts
+++ b/packages/core/src/types/state.ts
@@ -1,7 +1,7 @@
 import { GestureKey } from './config'
 import { NonUndefined, Vector2, WebKitGestureEvent } from './utils'
 
-export type IngKey = 'dragging' | 'wheeling' | 'moving' | 'hovering' | 'scrolling' | 'pinching'
+export type IngKey = 'dragging' | 'wheeling' | 'moving' | 'hovering' | 'scrolling' | 'pinching' | 'tapping'
 
 export type SharedGestureState = {
   /**
@@ -28,6 +28,10 @@ export type SharedGestureState = {
    * True if the element is being pinched.
    */
   pinching?: boolean
+  /**
+   * True if the element is being tapped (long press active).
+   */
+  tapping?: boolean
   /**
    * Number of fingers touching the screen.
    */
@@ -247,6 +251,34 @@ export interface PinchState extends CommonGestureState {
   cancel(): void
 }
 
+export type TapState = CoordinatesState & {
+  _pointerId?: number
+  _pointerActive: boolean
+  _waitingForSecondTap: boolean
+  _lastUpTime: number
+  _longPressTriggered: boolean
+
+  /**
+   * The number of taps detected (1 for single, 2 for double).
+   */
+  tapCount: number
+  /**
+   * True when a single tap is confirmed (after tapTimeout with no second tap).
+   * Only set when tapDiscrimination config is true.
+   */
+  singleTap: boolean
+  /**
+   * True when a double tap is detected.
+   * Only set when tapDiscrimination config is true.
+   */
+  doubleTap: boolean
+  /**
+   * True when long press threshold is met (pointer held down for longPressTimeout).
+   * Only set when longPressTimeout config > 0.
+   */
+  longPress: boolean
+}
+
 export type EventTypes = {
   drag: PointerEvent | TouchEvent | MouseEvent | KeyboardEvent
   wheel: WheelEvent
@@ -254,6 +286,7 @@ export type EventTypes = {
   move: PointerEvent
   hover: PointerEvent
   pinch: PointerEvent | TouchEvent | WheelEvent | WebKitGestureEvent
+  tap: PointerEvent | MouseEvent | TouchEvent
 }
 
 export interface State {
@@ -264,6 +297,7 @@ export interface State {
   move?: CoordinatesState & { event: EventTypes['move'] }
   hover?: CoordinatesState & { event: EventTypes['hover'] }
   pinch?: PinchState & { event: EventTypes['pinch'] }
+  tap?: TapState & { event: EventTypes['tap'] }
 }
 
 export type FullGestureState<Key extends GestureKey> = SharedGestureState & NonUndefined<State[Key]>

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,6 +4,7 @@ export { useWheel } from './useWheel'
 export { useScroll } from './useScroll'
 export { useMove } from './useMove'
 export { useHover } from './useHover'
+export { useTap } from './useTap'
 export { useGesture } from './useGesture'
 export { createUseGesture } from './createUseGesture'
 

--- a/packages/react/src/useGesture.ts
+++ b/packages/react/src/useGesture.ts
@@ -1,4 +1,12 @@
-import { dragAction, pinchAction, scrollAction, wheelAction, moveAction, hoverAction } from '@use-gesture/core/actions'
+import {
+  dragAction,
+  pinchAction,
+  scrollAction,
+  wheelAction,
+  moveAction,
+  hoverAction,
+  tapAction
+} from '@use-gesture/core/actions'
 import { GestureHandlers, UserGestureConfig, EventTypes, AnyHandlerEventTypes } from '@use-gesture/core/types'
 import { createUseGesture } from './createUseGesture'
 
@@ -14,6 +22,14 @@ export function useGesture<
   HandlerTypes extends AnyHandlerEventTypes = EventTypes,
   Config extends UserGestureConfig = UserGestureConfig
 >(handlers: GestureHandlers<HandlerTypes>, config?: Config) {
-  const hook = createUseGesture([dragAction, pinchAction, scrollAction, wheelAction, moveAction, hoverAction])
+  const hook = createUseGesture([
+    dragAction,
+    pinchAction,
+    scrollAction,
+    wheelAction,
+    moveAction,
+    hoverAction,
+    tapAction
+  ])
   return hook(handlers, config || ({} as Config))
 }

--- a/packages/react/src/useTap.ts
+++ b/packages/react/src/useTap.ts
@@ -1,0 +1,17 @@
+import { registerAction, tapAction } from '@use-gesture/core/actions'
+import { EventTypes, UserTapConfig, Handler } from '@use-gesture/core/types'
+import { useRecognizers } from './useRecognizers'
+
+/**
+ * Tap hook.
+ *
+ * @param {Handler<'tap'>} handler - the function fired every time the tap gesture updates
+ * @param {UserTapConfig} config - the config object including generic options and tap options
+ */
+export function useTap<EventType = EventTypes['tap'], Config extends UserTapConfig = UserTapConfig>(
+  handler: Handler<'tap', EventType>,
+  config?: Config
+) {
+  registerAction(tapAction)
+  return useRecognizers({ tap: handler }, config || {}, 'tap')
+}

--- a/test/tap.test.tsx
+++ b/test/tap.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react'
+import { render, cleanup, fireEvent, createEvent } from '@testing-library/react'
+import { later, patchCreateEvent } from './utils'
+import '@testing-library/jest-dom/extend-expect'
+import Interactive from './components/Interactive'
+import InteractiveDom from './components/InteractiveDom'
+import { InteractiveType } from './components/types'
+
+afterAll(cleanup)
+patchCreateEvent(createEvent)
+
+describe.each([
+  ['attached to component', Interactive, ''],
+  ['attached to node', InteractiveDom, 'dom-']
+])('testing onTap %s', (_testName, C, prefix): any => {
+  const Component = C as InteractiveType
+  let getByTestId: any
+  let rerender: any
+  let element: HTMLElement
+
+  beforeAll(() => {
+    const result = render(<Component gestures={['Tap']} memoArg="memo" />)
+    getByTestId = result.getByTestId
+    rerender = result.rerender
+    element = getByTestId(`${prefix}tap-el`)
+  })
+
+  test('pointerDown should initiate the gesture', () => {
+    const event = createEvent.pointerDown(element, { pointerId: 1, clientX: 10, clientY: 20, buttons: 1 })
+    fireEvent(element, event)
+
+    expect(getByTestId(`${prefix}tap-tapping`)).toHaveTextContent('true')
+    expect(getByTestId(`${prefix}tap-active`)).toHaveTextContent('true')
+    expect(getByTestId(`${prefix}tap-first`)).toHaveTextContent('true')
+    expect(getByTestId(`${prefix}tap-down`)).toHaveTextContent('true')
+  })
+
+  test('initiating the gesture should fire onTapStart', () => {
+    expect(getByTestId(`${prefix}tap-start`)).toHaveTextContent(/^fired$/)
+    expect(getByTestId(`${prefix}tap-end`)).toHaveTextContent(/^not fired$/)
+  })
+
+  test('testing memo value is passed', () => {
+    expect(getByTestId(`${prefix}tap-memo`)).toHaveTextContent('memo')
+  })
+
+  test('pointerUp should trigger the tap', async () => {
+    fireEvent.pointerUp(element, { pointerId: 1, clientX: 10, clientY: 20 })
+    await later(50)
+
+    expect(getByTestId(`${prefix}tap-tapCount`)).toHaveTextContent('1')
+    expect(getByTestId(`${prefix}tap-tapping`)).toHaveTextContent('false')
+    expect(getByTestId(`${prefix}tap-active`)).toHaveTextContent('false')
+    expect(getByTestId(`${prefix}tap-last`)).toHaveTextContent('true')
+  })
+
+  test('terminating the gesture should fire onTapEnd', () => {
+    expect(getByTestId(`${prefix}tap-end`)).toHaveTextContent(/^fired$/)
+  })
+
+  test('movement beyond threshold should cancel tap', async () => {
+    rerender(<Component gestures={['Tap']} memoArg="memo" />)
+    const downEvent = createEvent.pointerDown(element, { pointerId: 2, clientX: 0, clientY: 0, buttons: 1 })
+    fireEvent(element, downEvent)
+    const moveEvent = createEvent.pointerMove(element, { pointerId: 2, clientX: 50, clientY: 50, buttons: 1 })
+    fireEvent(element, moveEvent)
+    const upEvent = createEvent.pointerUp(element, { pointerId: 2, clientX: 50, clientY: 50 })
+    fireEvent(element, upEvent)
+
+    await later(50)
+
+    // State should not have been updated (tap canceled)
+    expect(getByTestId(`${prefix}tap-tapCount`)).toHaveTextContent('0')
+  })
+
+  test('disabling all gestures should prevent state from updating', () => {
+    rerender(<Component gestures={['Tap']} config={{ enabled: false }} />)
+    const downEvent = createEvent.pointerDown(element, { pointerId: 3, buttons: 1 })
+    fireEvent(element, downEvent)
+    expect(getByTestId(`${prefix}tap-tapping`)).toHaveTextContent('false')
+  })
+
+  test('disabling the tap gesture should prevent state from updating', () => {
+    rerender(<Component gestures={['Tap']} config={{ tap: { enabled: false } }} />)
+    const downEvent = createEvent.pointerDown(element, { pointerId: 4, buttons: 1 })
+    fireEvent(element, downEvent)
+    expect(getByTestId(`${prefix}tap-tapping`)).toHaveTextContent('false')
+  })
+
+  test('restart gesture with discrimination enabled', async () => {
+    rerender(<Component gestures={['Tap']} config={{ tap: { tapDiscrimination: true, tapTimeout: 100 } }} />)
+    const downEvent = createEvent.pointerDown(element, { pointerId: 10, clientX: 10, clientY: 20, buttons: 1 })
+    fireEvent(element, downEvent)
+    const upEvent = createEvent.pointerUp(element, { pointerId: 10, clientX: 10, clientY: 20 })
+    fireEvent(element, upEvent)
+
+    // Single tap shouldn't be confirmed immediately
+    expect(getByTestId(`${prefix}tap-singleTap`)).toHaveTextContent('false')
+
+    // Wait for timeout
+    await later(150)
+
+    expect(getByTestId(`${prefix}tap-singleTap`)).toHaveTextContent('true')
+  })
+
+  test('should detect double tap when two quick taps occur', async () => {
+    rerender(<Component gestures={['Tap']} config={{ tap: { tapDiscrimination: true, tapTimeout: 300 } }} />)
+
+    // First tap
+    const downEvent1 = createEvent.pointerDown(element, { pointerId: 20, clientX: 10, clientY: 20, buttons: 1 })
+    fireEvent(element, downEvent1)
+    const upEvent1 = createEvent.pointerUp(element, { pointerId: 20, clientX: 10, clientY: 20 })
+    fireEvent(element, upEvent1)
+
+    await later(50)
+
+    // Second tap (within timeout)
+    const downEvent2 = createEvent.pointerDown(element, { pointerId: 21, clientX: 10, clientY: 20, buttons: 1 })
+    fireEvent(element, downEvent2)
+    const upEvent2 = createEvent.pointerUp(element, { pointerId: 21, clientX: 10, clientY: 20 })
+    fireEvent(element, upEvent2)
+
+    await later(50)
+
+    expect(getByTestId(`${prefix}tap-doubleTap`)).toHaveTextContent('true')
+    expect(getByTestId(`${prefix}tap-tapCount`)).toHaveTextContent('2')
+  })
+
+  test('should detect long press after timeout', async () => {
+    rerender(<Component gestures={['Tap']} config={{ tap: { longPressTimeout: 100 } }} />)
+    const downEvent = createEvent.pointerDown(element, { pointerId: 40, clientX: 10, clientY: 20, buttons: 1 })
+    fireEvent(element, downEvent)
+
+    // Wait for long press timeout
+    await later(150)
+
+    expect(getByTestId(`${prefix}tap-longPress`)).toHaveTextContent('true')
+  })
+})


### PR DESCRIPTION
## Summary

  - Add new tap gesture engine (`TapEngine`) with discrimination between single taps, double taps, and long presses
  - Export `useTap` hook in `@use-gesture/react` package
  - Add `tapConfigResolver` with configurable options for tap behavior
  - Include comprehensive test suite for tap gesture functionality
  - Add interactive demo sandbox for tap gesture testing

  ## Tap Gesture Features

  | State | Description |
  |-------|-------------|
  | `singleTap` | Confirmed after `tapTimeout` with no second tap |
  | `doubleTap` | Two taps within `tapTimeout` window |
  | `longPress` | Pointer held for `longPressTimeout` ms |
  | `tapCount` | Number of taps detected (1 or 2) |

  ## Configuration Options

  | Option | Default | Description |
  |--------|---------|-------------|
  | `tapDiscrimination` | `true` | Enable single/double tap discrimination |
  | `tapTimeout` | `180ms` | Max time between taps for double tap |
  | `longPressTimeout` | `0` | Time to trigger long press (0 = disabled) |
  | `moveThreshold` | `10px` | Max movement before tap is canceled |

  ## Usage

  ```tsx
  import { useTap } from '@use-gesture/react'

  const bind = useTap(({ singleTap, doubleTap, longPress, tapCount }) => {
    if (singleTap) console.log('single tap')
    if (doubleTap) console.log('double tap')
    if (longPress) console.log('long press')
  })

  return <div {...bind()} />
```
close #241 